### PR TITLE
NEW options

### DIFF
--- a/admin/nomenclature_setup.php
+++ b/admin/nomenclature_setup.php
@@ -186,6 +186,24 @@ print '<td align="center" width="300">';
 print ajax_constantonoff('NOMENCLATURE_ACTIVATE_DETAILS_COSTS');
 print '</td></tr>';
 
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('NOMENCLATURE_TAKE_PRICE_FROM_CHILD_FIRST').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('NOMENCLATURE_TAKE_PRICE_FROM_CHILD_FIRST');
+print '</td></tr>';
+
+
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans('NOMENCLATURE_PERSO_PRICE_HAS_TO_BE_CHARGED').'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="center" width="300">';
+print ajax_constantonoff('NOMENCLATURE_PERSO_PRICE_HAS_TO_BE_CHARGED');
+print '</td></tr>';
+
+
 print '</table>';
 
 

--- a/langs/fr_FR/nomenclature.lang
+++ b/langs/fr_FR/nomenclature.lang
@@ -90,3 +90,6 @@ PercentUP=Augmentation en %
 ShowImpact=Montrer l'impact
 QtyAfter=Qté après
 MakeIt=Faire la mise à jour
+
+NOMENCLATURE_TAKE_PRICE_FROM_CHILD_FIRST=Utiliser le prix de la nomenclature enfant avant le prix d'achat pour le calcul
+NOMENCLATURE_PERSO_PRICE_HAS_TO_BE_CHARGED=Le prix personnalisé d'un composant est un déboursé


### PR DESCRIPTION
NOMENCLATURE_TAKE_PRICE_FROM_CHILD_FIRST prend le prix de l'enfant calculé plutôt que le prix d'achat

NOMENCLATURE_PERSO_PRICE_HAS_TO_BE_CHARGED un prix perso est une valeur à multiplier par le coefficient