### PR TITLE
Fix appliquer un prix de vente sur une ligne libre génère une erreur

### DIFF
--- a/nomenclature.php
+++ b/nomenclature.php
@@ -108,12 +108,10 @@ else if($action==='save_nomenclature') {
 				{
 					if ($line->id == $fk_object)
 					{
-						$productPropaleLine = new Product($db);
-						$productPropaleLine->fetch($fk_product);
 						$price_buy = $price_buy_init / $line->qty;
 						$price_to_sell = $price_to_sell_init / $line->qty;
 
-						$propal->updateline($fk_object, $price_to_sell, $line->qty, $line->remise_percent, $productPropaleLine->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $price_buy, $line->product_label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit);
+						$propal->updateline($fk_object, $price_to_sell, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $price_buy, $line->product_label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit);
 					}
 				}
 


### PR DESCRIPTION
De plus charger la TVA du produit d'origine n'est pas forcement un bon comportement