### PR TITLE
FIX cacher prix de revient à l'ajout d'un produit

### DIFF
--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -102,13 +102,13 @@ class Actionsnomenclature
 				
 				<script type="text/javascript"> 
 					$(document).ready(function() {
-						$("#idprod").change(function() {
-							var prod_id = $(this).val();
-							var data = {"action": "idprod_change", "prod_id": prod_id};
+						$("#fournprice_predef").ready(function(){$("#idprod").change(function() {
+							var fk_product = $(this).val();
+							var data = {"action": "idprod_change", "fk_product": fk_product};
 							 ajax_call(data);
 							
 								
-						});
+						})});
 						function ajax_call(datas)
 						{
 							$.ajax({
@@ -116,20 +116,18 @@ class Actionsnomenclature
 								type: "POST",
 								dataType: "json",
 								data: datas,
-								success: function(data){
-									
-									if(data.result){
-										setTimeout(function(){ $("#fournprice_predef").hide();$(".liste_titre_add td:contains('Prix de revient')").hide();}, 300);
+								
+							}).done(function(data){
+								if(data.result){
+										 $("#fournprice_predef").hide();
+										 $(".liste_titre_add td:contains('Prix de revient')").hide();
 										
 									} else {
 										$("#fournprice_predef").show();
 										$(".liste_titre_add td:contains('Prix de revient')").show();
-									}					
-									
-								},
-								error: function(error){
-									$.jnotify('AjaxError',"error");
-								}
+									}		
+							}).fail(function(){
+								$.jnotify('AjaxError',"error");
 							});
 						}
 					});

--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -99,7 +99,43 @@ class Actionsnomenclature
 					}
 				</style>
 				
+				
+				<script type="text/javascript"> 
+					$(document).ready(function() {
+						$("#idprod").change(function() {
+							var prod_id = $(this).val();
+							var data = {"action": "idprod_change", "prod_id": prod_id};
+							 ajax_call(data);
+							
+								
+						});
+						function ajax_call(datas)
+						{
+							$.ajax({
+								url: "<?php echo dol_buildpath('/nomenclature/prod_ajax.php', 1) ; ?>",
+								type: "POST",
+								dataType: "json",
+								data: datas,
+								success: function(data){
+									
+									if(data.result){
+										setTimeout(function(){ $("#fournprice_predef").hide();$(".liste_titre_add td:contains('Prix de revient')").hide();}, 300);
+										
+									} else {
+										$("#fournprice_predef").show();
+										$(".liste_titre_add td:contains('Prix de revient')").show();
+									}					
+									
+								},
+								error: function(error){
+									$.jnotify('AjaxError',"error");
+								}
+							});
+						}
+					});
+				</script>
 				<?php
+				
 			}
 			
 		}

--- a/prod_ajax.php
+++ b/prod_ajax.php
@@ -17,9 +17,9 @@ if(GETPOST('action'))
 		
 		if($action == 'idprod_change')
 		{
-			$prod_id= (int)GETPOST('prod_id');
+			$fk_product= (int)GETPOST('fk_product');
 			$nomenclature = new TNomenclature();
-			$nomenclature->loadByObjectId($PDOdb, $prod_id, 'product');
+			$nomenclature->loadByObjectId($PDOdb, $fk_product, 'product');
 			
 			
 			if($nomenclature->iExist)

--- a/prod_ajax.php
+++ b/prod_ajax.php
@@ -1,0 +1,35 @@
+<?php
+
+/* 
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+require 'config.php';
+dol_include_once('/nomenclature/class/nomenclature.class.php');
+
+$PDOdb = new TPDOdb;
+if(GETPOST('action'))
+	{
+		$action = GETPOST('action');
+		
+		
+		if($action == 'idprod_change')
+		{
+			$prod_id= (int)GETPOST('prod_id');
+			$nomenclature = new TNomenclature();
+			$nomenclature->loadByObjectId($PDOdb, $prod_id, 'product');
+			
+			
+			if($nomenclature->iExist)
+			{
+				$data['result'] = 1;
+			}
+			else
+			{
+				$data['result'] = 0;
+			}
+		}
+	}
+echo json_encode($data);


### PR DESCRIPTION
Pour retour btp, demande de cacher le prix de revient sur les propals à l'ajout d'un produit

"Masquer le sélection du prix de revient sur la ligne si c’est un produit présélectionner car elle provient de la nomenclature (donc uniquement si nomenclature existe sur produit présélectionner)"