### PR TITLE
Fix PDO DB ErrorGetLine

### DIFF
--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -461,7 +461,7 @@ class TNomenclature extends TObjetStd
 
 		$sql = "SELECT fk_workstation, nb_hour,nb_hour_prepare,nb_hour_manufacture";
 		$sql.= " FROM ".MAIN_DB_PREFIX."workstation_product";
-		$sql.= " WHERE fk_product = ".$fk_product;
+		$sql.= " WHERE fk_product = ".$this->fk_object;
 		$PDOdb->Execute($sql);
 
 		while($res = $PDOdb->Get_line())

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -59,7 +59,7 @@ class modnomenclature extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.3.1';
+		$this->version = '1.3.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
la variable $fk_product n'existe pas, l'id est contenu dans l'objet courant dans l'attribut fk_object