### PR TITLE
New clone nomenclature on duplicate of subtotal

### DIFF
--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -51,6 +51,16 @@ class TNomenclature extends TObjetStd
         }
     }
 	
+	function cloneObject(&$PDOdb, $fk_object=0)
+	{
+		if ($this->object_type !== 'product' && $fk_object > 0)
+		{
+			$this->fk_object = $fk_object; // On conserve le type de l'objet (propal) mais pas le fk_
+		}
+		
+		return parent::cloneObject($PDOdb);
+	}
+	
 	function getBuyPrice()
 	{
 		global $conf;

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -59,7 +59,7 @@ class modnomenclature extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.4.0';
+		$this->version = '1.5.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
+++ b/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
@@ -260,6 +260,20 @@ class Interfacenomenclaturetrigger
 			
 		} elseif ($action == 'ORDER_DELETE') {
 			$this->_deleteNomenclature($PDOdb, $db, $object, 'commande');
+		} elseif ($action == 'LINE_DUPLICATE') {
+			
+			if ($object->line_from->product_type != 9)
+			{
+				$n = new TNomenclature;
+				$n->loadByObjectId($PDOdb, $object->line_from->id, $object->element, true, $object->line_from->fk_product, $object->line_from->qty);
+				
+				// S'il y a bien un load depuis ma ligne de propal d'origine
+				if ($n->iExist)
+				{
+					$n->cloneObject($PDOdb, $object->line->id);
+				}
+			}
+			
 		}
 
 		return 0;


### PR DESCRIPTION
Une action de subtotal permet de dupliquer un bloque, par conséquent les nomenclatures qui sont liées aux lignes de propal sont elles aussi dupliqué