### PR TITLE
Fix loss percent math

### DIFF
--- a/nomenclature.php
+++ b/nomenclature.php
@@ -494,7 +494,6 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
 					var val_qty_base = $(line).find("input[name*=qty_base]").val();
 					var val_loss_percent = $(line).find("input[name*=loss_percent]").val();
 					
-					//$(this).closest('tr').find('td.ligne_col_qty').find("input[name*=qty]").val(Math.round(((val_qty_base / ((100 - val_loss_percent)/100)) * 100)) / 100);
 					var newQty = val_qty_base * ( 1 +  val_loss_percent / 100 );
 					newQty = Math.round(newQty*100)/100;
 					$(this).closest('tr').find('td.ligne_col_qty').find("input[name*=qty]").val(newQty);

--- a/nomenclature.php
+++ b/nomenclature.php
@@ -494,8 +494,10 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
 					var val_qty_base = $(line).find("input[name*=qty_base]").val();
 					var val_loss_percent = $(line).find("input[name*=loss_percent]").val();
 					
-					$(this).closest('tr').find('td.ligne_col_qty').find("input[name*=qty]").val(Math.round(((val_qty_base / ((100 - val_loss_percent)/100)) * 100)) / 100);
-
+					//$(this).closest('tr').find('td.ligne_col_qty').find("input[name*=qty]").val(Math.round(((val_qty_base / ((100 - val_loss_percent)/100)) * 100)) / 100);
+					var newQty = val_qty_base * ( 1 +  val_loss_percent / 100 );
+					newQty = Math.round(newQty*100)/100;
+					$(this).closest('tr').find('td.ligne_col_qty').find("input[name*=qty]").val(newQty);
 				}
 				
 			});


### PR DESCRIPTION
changement de la formule de calcule du pourcentage de perte : qté x pourcentage = qté finale et non qté / (qté - pourcentage)

Avant de merger, est-ce que l'ancienne méthode parle à qq1 ? pour quelle raison est-ce que l'on calculait ainsi ? (ou alors c'est juste un vieux truc bogué et je me pose trop de question ... c'est possible aussi) 