### PR TITLE
T1981 - add TNomenclature::element + TNomenclatureDet::element

### DIFF
--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -36,6 +36,9 @@ class TNomenclature extends TObjetStd
 	/** @var null|TPDOdb */
 	public $PDOdb = null;
 
+	/** @var string $element */
+	public $element = 'nomenclature';
+
     function __construct()
     {
         global $conf;
@@ -1104,6 +1107,10 @@ class TNomenclatureDet extends TObjetStd
 	/**
 	 * product_type == fk_coef (rowid de la table nomenclature_coef)
 	 */
+
+	/** @var string $element */
+	public $element = 'nomenclaturedet';
+
     function __construct()
     {
     	global $conf;


### PR DESCRIPTION
Je ne les ai pas mis en `static` (en général, dans Dolibarr, ce n’est pas static non plus), mais peut-être que ce serait préférable (ça éviterait d’instancier des objets juste pour accéder à ces propriétés-là).