### PR TITLE
Fix 2.0 t1973 addproduct scroll

### DIFF
--- a/nomenclature.php
+++ b/nomenclature.php
@@ -163,14 +163,19 @@ if (empty($reshook))
 	
 		    $fk_new_product = (int)GETPOST('fk_new_product_'.$n->getId());
 		    if(GETPOST('add_nomenclature') && $fk_new_product>0) {
-		    	if(!$n->addProduct($PDOdb, $fk_new_product)) {
+                if(!$n->addProduct($PDOdb, $fk_new_product)) {
 					$p_err= new Product($db);
 					$p_err->fetch($fk_new_product);
-	
 					setEventMessage($langs->trans('ThisProductCreateAnInfinitLoop').' '.$p_err->getNomUrl(0),'errors');
-		    	}
-	
-		    }
+		    	} else
+                {
+                    $last_det = end($n->TNomenclatureDet);
+                    $url = dol_buildpath('nomenclature/nomenclature.php', 2).'?fk_product='.$n->fk_object.'#line_'.$last_det->rowid;
+
+                    header("location: ".$url, true);
+                    exit;
+                }
+            }
 	
 		    $fk_new_workstation = GETPOST('fk_new_workstation');
 		    if(GETPOST('add_workstation') && $fk_new_workstation>0 ) {
@@ -604,9 +609,9 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
                        foreach($TNomenclatureDet as $k=>&$det) {
 
                            $class = ($class == 'impair') ? 'pair' : 'impair';
-                           
+
                            ?>
-                           <tr class="<?php echo $class ?>" rowid="<?php echo $det->getId(); ?>">
+                           <tr class="<?php echo $class ?>" rowid="<?php echo $det->getId(); ?>" id="line_<?php echo $det->getId(); ?>">
                                <td><?php
                                     $p_nomdet = new Product($db);
                                     if ($det->fk_product>0 && $p_nomdet->fetch($det->fk_product)>0)

--- a/nomenclature.php
+++ b/nomenclature.php
@@ -170,7 +170,7 @@ if (empty($reshook))
 		    	} else
                 {
                     $last_det = end($n->TNomenclatureDet);
-                    $url = dol_buildpath('nomenclature/nomenclature.php', 2).'?fk_product='.$n->fk_object.'#line_'.$last_det->rowid;
+                    $url = dol_buildpath('nomenclature/nomenclature.php', 2).'?fk_product='.$n->fk_object.'&fk_nomenclature='.$n->getId().'#line_'.(intval($last_det->rowid));
 
                     header("location: ".$url, true);
                     exit;
@@ -329,7 +329,7 @@ function _show_product_nomenclature(&$PDOdb, &$product, &$object) {
 	    
 	    if(!empty($fk_nomenclature) && $fk_nomenclature == $n->id){ $accordeonActiveIndex = $idion; }
 	    $idion++;
-	    
+
 		// On passe par là depuis l'onglet "Ouvrage" d'un produit, du coup il faut passer la qty_reference de la nomenclature
 	    _fiche_nomenclature($PDOdb, $n, $product, $object, $product->id, 'product', $n->qty_reference);
 	}


### PR DESCRIPTION
Lorsque l'on ajoute un produit dans une nomenclature, suite au rechargement, l'affichage se place au niveau de la ligne ajoutée et non plus au début de la page.