### PR TITLE
3.0 - FIX: fatal when adding a line to a nomenclature whose fk object is not a product

### DIFF
--- a/nomenclature.php
+++ b/nomenclature.php
@@ -169,8 +169,7 @@ if (empty($reshook))
 					$p_err->fetch($fk_new_product);
 	
 					setEventMessage($langs->trans('ThisProductCreateAnInfinitLoop').' '.$p_err->getNomUrl(0),'errors');
-		    	} else
-                {
+				} elseif ($n->object_type === 'product') {
                     $last_det = end($n->TNomenclatureDet);
                     $url = dol_buildpath('nomenclature/nomenclature.php', 2).'?fk_product='.$n->fk_object.'&fk_nomenclature='.$n->getId().'#line_'.(intval($last_det->rowid));
 


### PR DESCRIPTION
In the redirect URL, `fk_product` was set to `$n->fk_object` which caused the page to attempt to load a product with the ID of a different type of object, for instance in the case of an order line’s nomenclature.