### PR TITLE
Fix 3.0 in read-only mode, add visual separation between label and private note of lines of nomenclature

### DIFF
--- a/nomenclature.php
+++ b/nomenclature.php
@@ -651,7 +651,9 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
 
                                     $sub_n = _draw_child_arbo($PDOdb, $p_nomdet->id, $det->qty);
 
+									if ($readonly) echo '<div class="note_private">';
 									echo $formCore->zonetexte('', 'TNomenclature['.$k.'][note_private]', $det->note_private, 80, 1,' style="width:95%;"');
+									if ($readonly) echo '</div>';
 
 									if(!empty($conf->global->NOMENCLATURE_ALLOW_TO_LINK_PRODUCT_TO_WORKSTATION)) {
 									


### PR DESCRIPTION
Before, there was not even a space between the label and the private note, which was not pleasant to read.