### PR TITLE
FIX : tk10987 : les coefficients de marge MO ne sont jamais appliqués…

### DIFF
--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -193,6 +193,7 @@ class TNomenclature extends TObjetStd
         }
 
 		$this->TCoefStandard = TNomenclatureCoef::loadCoef($PDOdb);
+		$this->TCoefStandard += TNomenclatureCoef::loadCoef($PDOdb, 'workstation');
 		if(!empty($object->id)) $this->TCoefObject = TNomenclatureCoefObject::loadCoefObject($PDOdb, $object, $object_type);
 
 		// vérifier l'éxistance de coef produit : non prioritaire au coef de l'objet


### PR DESCRIPTION
… sur la main d'oeuvre d'une nomenclature