### PR TITLE
FIX 2.0 - when recomputing sell price of proposal lines, check that the nomenclature line exists

### DIFF
--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -685,7 +685,16 @@ class TNomenclature extends TObjetStd
         return 1;
     }
 
-
+	/**
+	 * @param TPDOdb $PDOdb
+	 * @param int $fk_object
+	 * @param string $object_type
+	 * @param bool $loadProductWSifEmpty
+	 * @param int $fk_product
+	 * @param int $qty
+	 * @param int $fk_origin
+	 * @return bool True if found, False if not
+	 */
 	function loadByObjectId(&$PDOdb, $fk_object, $object_type, $loadProductWSifEmpty = false, $fk_product = 0, $qty = 1, $fk_origin=0) {
 	    $sql = "SELECT rowid FROM ".$this->get_table()."
             WHERE fk_object=".(int)$fk_object." AND object_type='".$object_type."'";

--- a/nomenclature_coef.php
+++ b/nomenclature_coef.php
@@ -316,9 +316,10 @@ function _updateLinePriceObject(&$PDOdb, &$db, &$conf, &$langs, &$user, $object_
 		if ($line->product_type == 9 || (!empty($conf->global->NOMENCLATURE_DONT_RECALCUL_IF_PV_FORCE) && !empty($line->array_options['options_pv_force']))) continue;
 
 		$nomenclature = new TNomenclature;
-		$nomenclature->loadByObjectId($PDOdb, $line->id, 'propal', true, $line->fk_product, $line->qty);
-		$nomenclature->setPrice($PDOdb,$line->qty,$line->id,'propal',$object->id);
+		$loaded = $nomenclature->loadByObjectId($PDOdb, $line->id, 'propal', true, $line->fk_product, $line->qty);
 
+		if (!$loaded) continue;
+		$nomenclature->setPrice($PDOdb,$line->qty,$line->id,'propal',$object->id);
 
 		_updateObjectLine($nomenclature, $object_type, $line->id, $object->id, true);
 


### PR DESCRIPTION
# Issue
When clicking on “recalculer le prix de vente des lignes” (“coefficient” tab on a proposal card), the sell price of all the proposal lines that don’t have a nomenclature was set to 0.

# Cause
`_updateLinePriceObject()` attempts to load a nomenclature object attached to each line of the object, then updates the price using the loaded nomenclature object, except that it doesn’t check the result of `nomenclature->loadByObjectId()`.

# Fix
The check was added.