### PR TITLE
FIX : Lors de l'ajout d'une ligne dans Propal, l'icône "nomenclature" ne s'…

### DIFF
--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -138,6 +138,9 @@ class Actionsnomenclature
 		
 		if (in_array('propalcard', $TContext) || in_array('ordercard', $TContext))
 		{
+
+            $ret = $object->fetch($object->id); // Reload to get new records
+
 			if (count($object->lines) > 0)
 			{
 			?>


### PR DESCRIPTION
Il est nécessaire de recharger l'objet afin d'obtenir la dernière ligne créée et d'en prendre compte pour l'affichage de l'icône "nomenclature".