### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/import.php
+++ b/admin/import.php
@@ -34,9 +34,9 @@ function _card(&$PDOdb) {
 	    "nomenclature@nomenclature"
 	);
 
-	
+
 	print '<h3>'.$langs->trans('NomenclatureImportTitle').'</h3>';
-	
+
 	$formCore=new TFormCore('auto','formImport','post',true);
 
 	echo $formCore->fichier($langs->trans('importFile').img_help(1, $langs->trans('helpNomenclatureImportFile')) , 'file1', '', 40);
@@ -59,7 +59,7 @@ function _show_tab_session(&$PDOdb) {
 
 	$Tab = &$_SESSION['TDataImport'];
 
-	$save = GETPOST('bt_save') ? true : false;
+	$save = GETPOST('bt_save', 'none') ? true : false;
 	//var_dump($Tab);
 	if (!empty($Tab))
 	{
@@ -182,7 +182,7 @@ function _show_nomenclature(&$n) {
 
 function _import_to_session() {
 
-	if(GETPOST('bt_view') && !empty($_FILES['file1']['name'])) {
+	if(GETPOST('bt_view', 'none') && !empty($_FILES['file1']['name'])) {
 		$Tab = &$_SESSION['TDataImport'];
 		$Tab = array();
 

--- a/admin/nomenclature_setup.php
+++ b/admin/nomenclature_setup.php
@@ -57,7 +57,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		setEventMessage($langs->trans("ParamSaved"));
 

--- a/admin/nomenclature_setup_btp.php
+++ b/admin/nomenclature_setup_btp.php
@@ -51,7 +51,7 @@ if ($action == 'add' || $action == 'edit')
 {
 	$id = GETPOST('rowid', 'int');
 
-	if (GETPOST('delete'))
+	if (GETPOST('delete', 'alpha'))
 	{
 		$nomenclatureCoef = new TNomenclatureCoef;
 		$nomenclatureCoef->load($PDOdb, $id);
@@ -72,7 +72,7 @@ if ($action == 'add' || $action == 'edit')
 			$nomenclatureCoef = new TNomenclatureCoef;
 
 			if ($id) $nomenclatureCoef->load($PDOdb, $id);
-			else $nomenclatureCoef->type = GETPOST('line_type');
+			else $nomenclatureCoef->type = GETPOST('line_type', 'none');
 
 			$nomenclatureCoef->label = $label;
 			$nomenclatureCoef->description = $desc;
@@ -103,7 +103,7 @@ $TCoefWS = TNomenclatureCoef::loadCoef($PDOdb, 'workstation');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		setEventMessage($langs->trans("ParamSaved"));
 

--- a/admin/nomenclature_setup_coeff.php
+++ b/admin/nomenclature_setup_coeff.php
@@ -52,7 +52,7 @@ if ($action == 'add' || $action == 'edit')
 {
 	$id = GETPOST('rowid', 'int');
 
-	if (GETPOST('delete'))
+	if (GETPOST('delete', 'alpha'))
 	{
 		$nomenclatureCoef = new TNomenclatureCoef;
 		$nomenclatureCoef->load($PDOdb, $id);
@@ -86,7 +86,7 @@ if ($action == 'add' || $action == 'edit')
 			$nomenclatureCoef = new TNomenclatureCoef;
 
 			if ($id) $nomenclatureCoef->load($PDOdb, $id);
-			else $nomenclatureCoef->type = GETPOST('line_type');
+			else $nomenclatureCoef->type = GETPOST('line_type', 'none');
 
 			$nomenclatureCoef->label = $label;
 			$nomenclatureCoef->description = $desc;
@@ -120,7 +120,7 @@ if(empty($TCoefFinal)) 	$msg = get_htmloutput_mesg(img_warning('default') . ' ' 
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		setEventMessage($langs->trans("ParamSaved"));
 

--- a/ajax/products.php
+++ b/ajax/products.php
@@ -1,6 +1,6 @@
 <?php
 /* Copié collé de htdocs/product/ajax/product.php dans le but de customiser la requête sql, et donc de récupérer que les produits ayant au moins 1 nomenclature
- * 
+ *
  * Copyright (C) 2006      Andre Cianfarani     <acianfa@free.fr>
  * Copyright (C) 2005-2013 Regis Houssin        <regis.houssin@capnetworks.com>
  * Copyright (C) 2007-2011 Laurent Destailleur  <eldy@users.sourceforge.net>
@@ -173,17 +173,17 @@ if (! empty($action) && $action == 'fetch' && ! empty($id))
 	sort($match);
 	$idprod = (! empty($match [0]) ? $match [0] : '');
 
-	if (! GETPOST($htmlname) && ! GETPOST($idprod))
+	if (! GETPOST($htmlname, 'none') && ! GETPOST($idprod, 'none'))
 		return;
 
 		// When used from jQuery, the search term is added as GET param "term".
 	$searchkey='';
-	if(GETPOST($idprod) && GETPOST($idprod) !== 'BadFirstParameterForGETPOST') {
-		$searchkey = GETPOST($idprod);
-	} elseif(GETPOST($htmlname) && GETPOST($htmlname) !== 'BadFirstParameterForGETPOST'){
-		$searchkey = GETPOST($htmlname);
+	if(GETPOST($idprod, 'none') && GETPOST($idprod, 'none') !== 'BadFirstParameterForGETPOST') {
+		$searchkey = GETPOST($idprod, 'none');
+	} elseif(GETPOST($htmlname, 'none') && GETPOST($htmlname, 'none') !== 'BadFirstParameterForGETPOST'){
+		$searchkey = GETPOST($htmlname, 'none');
 	}
-	
+
 	$form = new Form($db);
 	if (empty($mode) || $mode == 1) {
 		$arrayresult = $form->select_produits_list("", $htmlname, $type, "", $price_level, $searchkey, $status, 2, $outjson, $socid);
@@ -194,15 +194,15 @@ if (! empty($action) && $action == 'fetch' && ! empty($id))
 	/* CUSTOM CODE */
 	$sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'product WHERE rowid IN (SELECT DISTINCT fk_object FROM '.MAIN_DB_PREFIX.'nomenclature WHERE object_type = "product")';
 	$resql = $db->query($sql);
-	
+
 	if ($resql && $db->num_rows($resql) > 0 && count($arrayresult) > 0)
 	{
 		$TIdFound = array();
-		while ($row = $db->fetch_object($resql)) 
+		while ($row = $db->fetch_object($resql))
 		{
 			$TIdFound[] = $row->rowid;
 		}
-		
+
 		foreach ($arrayresult as $index => &$TValue)
 		{
 			if (!in_array($TValue['key'], $TIdFound))

--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -83,7 +83,7 @@ class Actionsnomenclature
                         // On met à jour les extrafields des titres correspondant aux coefficiants
                         $TCoef = TNomenclatureCoef::loadCoef($PDOdb);
                         foreach($TCoef as $coef) {
-                            $line->array_options['options_'.$coef->code_type] = GETPOST($coef->code_type);
+                            $line->array_options['options_'.$coef->code_type] = GETPOST($coef->code_type, 'none');
                         }
                         $line->insertExtraFields();
                     }
@@ -124,7 +124,7 @@ class Actionsnomenclature
                 $TCoef = TNomenclatureCoef::loadCoef($PDOdb);
 
                 foreach($TCoef as $coef) {
-                    $titleLine->array_options['options_'.$coef->code_type] = GETPOST($coef->code_type);
+                    $titleLine->array_options['options_'.$coef->code_type] = GETPOST($coef->code_type, 'none');
                 }
                 $titleLine->insertExtraFields();
             }
@@ -134,8 +134,8 @@ class Actionsnomenclature
 	function formObjectOptions($parameters, &$object, &$action, $hookmanager)
 	{
 		global $langs,$conf,$form;
-		$TContext = explode(':', $parameters['context']);		
-		
+		$TContext = explode(':', $parameters['context']);
+
 		if (in_array('propalcard', $TContext) || in_array('ordercard', $TContext))
 		{
 
@@ -145,7 +145,7 @@ class Actionsnomenclature
 			{
 			?>
 				<script type="text/javascript" src="<?php echo dol_buildpath('/nomenclature/js/nomenclature.js.php',1); ?>"></script>
-				<script type="text/javascript"> 
+				<script type="text/javascript">
 				$(document).ready(function() {
 
 					var lineColDescriptionPos = <?php echo (! empty($conf->global->MAIN_VIEW_LINE_NUMBER) ? 2 : 1); ?>;
@@ -179,16 +179,16 @@ class Actionsnomenclature
 						z-index: 150;
 					}
 				</style>
-				
-				
-				<script type="text/javascript"> 
+
+
+				<script type="text/javascript">
 					$(document).ready(function() {
 						$("#fournprice_predef").ready(function(){$("#idprod").change(function() {
 							var fk_product = $(this).val();
 							var data = {"action": "idprod_change", "fk_product": fk_product};
 							 ajax_call(data);
-							
-								
+
+
 						})});
 						function ajax_call(datas)
 						{
@@ -197,16 +197,16 @@ class Actionsnomenclature
 								type: "POST",
 								dataType: "json",
 								data: datas,
-								
+
 							}).done(function(data){
 								if(data.result){
 										 $("#fournprice_predef").hide();
 										 $(".liste_titre_add td:contains('Prix de revient')").hide();
-										
+
 									} else {
 										$("#fournprice_predef").show();
 										$(".liste_titre_add td:contains('Prix de revient')").show();
-									}		
+									}
 							}).fail(function(){
 								$.jnotify('AjaxError',"error");
 							});
@@ -214,23 +214,23 @@ class Actionsnomenclature
 					});
 				</script>
 				<?php
-				
+
 			}
-			
+
 		}
 		else if (in_array('stockproductcard', $TContext) && !empty($conf->global->NOMENCLATURE_ALLOW_MVT_STOCK_FROM_NOMEN))
 		{
 			if (!defined('INC_FROM_DOLIBARR')) define('INC_FROM_DOLIBARR', 1);
-			
+
 			dol_include_once('/nomenclature/config.php');
 			dol_include_once('/nomenclature/class/nomenclature.class.php');
-			
+
 			$PDOdb = new TPDOdb;
 			$nomenclature = new TNomenclature;
 			$nomenclature->loadByObjectId($PDOdb, $object->id, 'product');
-			
+
 			$qty_theo_nomenclature = $nomenclature->getQtyManufacturable();
-			
+
 			$this->resprints = '<tr class="nomenclature_stock_theorique">';
 			$this->resprints.= '<td>'.$form->textwithpicto($langs->trans('NomenclatureStockTheorique'), $langs->trans('NomenclatureStockTheoriqueHelp')).'</td>';
 			$this->resprints.= '<td>'.price2num($object->stock_theorique+$qty_theo_nomenclature, 'MS').'</td>';
@@ -296,7 +296,7 @@ class Actionsnomenclature
                                 var nomenEl = document.getElementById("TQuantites['.$object->fk_commandedet.']");
                                 nomenEl.dataset.step = '.$n->qty_reference.';
                                 $(nomenEl).after("'.dol_escape_js(img_picto($langs->transnoentities('NomenclatureWarningSeuilNonSecableHelp', $n->qty_reference), 'help')).'");
-// 
+//
                                 $(nomenEl).keyup(function(ev) {
                                     console.log("Trigger keyup from nomenclature");
                                     let value = parseFloat(this.value.replace(",", "."));
@@ -311,7 +311,7 @@ class Actionsnomenclature
                                         this.dataset.calculNextValue = 1;
                                     }
                                 });
-                                
+
                                 $(nomenEl).blur(function(ev) {
                                     console.log("Trigger blur from nomenclature");
                                     if (this.dataset.calculNextValue == 1) {
@@ -431,7 +431,7 @@ class Actionsnomenclature
                 $PDOdb = new TPDOdb;
 
                 $n = new TNomenclature;
-                $n->loadByObjectId($PDOdb, GETPOST('fk_product'), 'product', true); // si pas de fk_nomenclature, alors on provient d'un document, donc $qty_ref tjr passé en param
+                $n->loadByObjectId($PDOdb, GETPOST('fk_product', 'int'), 'product', true); // si pas de fk_nomenclature, alors on provient d'un document, donc $qty_ref tjr passé en param
 
                 if ($n->getId() > 0 && $n->non_secable)
                 {
@@ -446,12 +446,12 @@ class Actionsnomenclature
                                 var nomenEl = document.getElementById("quantity_to_create");
                                 nomenEl.value = '.$n->qty_reference.';
                                 nomenEl.dataset.step = '.$n->qty_reference.';
-                                
+
                                 $(nomenEl).keyup(function(ev) {
                                     console.log("Trigger keyup from nomenclature");
                                     let value = parseFloat(this.value.replace(",", "."));
                                     let multiple = value / this.dataset.step;
-            
+
                                     if (multiple === parseInt(multiple)) {
                                         $(this).removeClass("outline-error");
                                         this.dataset.calculNextValue = 0;
@@ -461,7 +461,7 @@ class Actionsnomenclature
                                         this.dataset.calculNextValue = 1;
                                     }
                                 });
-                                
+
                                 $(nomenEl).blur(function(ev) {
                                     console.log("Trigger blur from nomenclature");
                                     if (this.dataset.calculNextValue == 1) {

--- a/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
+++ b/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
@@ -161,8 +161,8 @@ class Interfacenomenclaturetrigger
 			if (empty($conf->nomenclature->enabled) || $object->product_type == 9)	return 0;
 
 			// Si on vient d'une propal on vérifie s'il existe une nomenclature associée à la propal :
-			$origin = GETPOST('origin');
-			$origin_id = GETPOST('originid'); // id de la ligne propal <= FAUX, id de la propal d'origin
+			$origin = GETPOST('origin', 'none');
+			$origin_id = GETPOST('originid', 'int'); // id de la ligne propal <= FAUX, id de la propal d'origin
 
 			// Module Workflow
 			if(empty($origin) && empty($origin_id) && ! empty($object->context['origin']) && ! empty($object->context['origin_id'])) {
@@ -227,7 +227,7 @@ class Interfacenomenclaturetrigger
 
 			// On load l'objet initial :
 			$o = new $classname($db);
-			$o->fetch(GETPOST('id'));
+			$o->fetch(GETPOST('id', 'int'));
 			$object->fetch($object->id); // Pour recharger les bonnes lignes qui sinon sont celles de l'objet de départ
 
 			if ($origin == 'propal') {
@@ -359,7 +359,7 @@ class Interfacenomenclaturetrigger
         }
 
 		if($action == 'PRODUCT_CREATE' && in_array('createfromclone', $object->context) && !empty($conf->global->NOMENCLATURE_CLONE_ON_PRODUCT_CLONE)) {
-			$origin_id = (!empty($object->origin_id) && $object->origin == 'product')?$object->origin_id:GETPOST('id');
+			$origin_id = (!empty($object->origin_id) && $object->origin == 'product')?$object->origin_id:GETPOST('id', 'int');
 			$TNomenclature = TNomenclature::get($PDOdb, $origin_id);
 			if(!empty($TNomenclature)) {
 				foreach($TNomenclature as $nomenclature) {

--- a/lib/nomenclature.lib.php
+++ b/lib/nomenclature.lib.php
@@ -152,8 +152,8 @@ function getFormConfirmNomenclature(&$form, &$product, $fk_nomenclature_used, $a
 			array('type' => 'hidden'	,'name' => 'fk_product'					,'value' => $product->id)
 			,array('type' => 'hidden'	,'name' => 'fk_nomenclature_used'		,'value' => $fk_nomenclature_used)
 			,array('type' => 'text'		,'name' => 'nomenclature_qty_to_create'	,'label' => $langs->trans('NomenclatureHowManyQty')				,'value' => $qty, 'moreattr' => 'size="5"')
-			,array('type' => 'other'	,'name' => 'fk_warehouse_to_make'		,'label' => $langs->trans('NomenclatureSelectWarehouseToMake')	,'value' => $formproduct->selectWarehouses(GETPOST('fk_warehouse_to_make'), 'fk_warehouse_to_make', 'warehouseopen,warehouseinternal', 0, 0, 0, '', 0, 0, null, 'minwidth200'))
-			,array('type' => 'other'	,'name' => 'fk_warehouse_needed'		,'label' => $langs->trans('NomenclatureSelectWarehouseNeeded')	,'value' => $formproduct->selectWarehouses(GETPOST('fk_warehouse_needed'), 'fk_warehouse_needed', 'warehouseopen,warehouseinternal', 0, 0, 0, '', 0, 0, null, 'minwidth200'))
+			,array('type' => 'other'	,'name' => 'fk_warehouse_to_make'		,'label' => $langs->trans('NomenclatureSelectWarehouseToMake')	,'value' => $formproduct->selectWarehouses(GETPOST('fk_warehouse_to_make', 'none'), 'fk_warehouse_to_make', 'warehouseopen,warehouseinternal', 0, 0, 0, '', 0, 0, null, 'minwidth200'))
+			,array('type' => 'other'	,'name' => 'fk_warehouse_needed'		,'label' => $langs->trans('NomenclatureSelectWarehouseNeeded')	,'value' => $formproduct->selectWarehouses(GETPOST('fk_warehouse_needed', 'none'), 'fk_warehouse_needed', 'warehouseopen,warehouseinternal', 0, 0, 0, '', 0, 0, null, 'minwidth200'))
 		);
 
         $formconfirm = $form->formconfirm($_SERVER['PHP_SELF'] . '?fk_product=' . $product->id, $langs->trans('NomenclatureCreateStock', $product->ref), $text, 'confirm_create_stock', $formquestion, 0, 1, 'auto');
@@ -206,7 +206,7 @@ function feedback_drawlines(&$object, $object_type, $TParam = array(), $editMode
 
     $fk_entrepot = GETPOST('fk_entrepot', 'int');
 
-    $qtyConsume = GETPOST('qtyConsume');
+    $qtyConsume = GETPOST('qtyConsume', 'none');
 
     dol_include_once('/product/class/product.class.php');
     dol_include_once('product/class/html.formproduct.class.php');

--- a/massUpdate.php
+++ b/massUpdate.php
@@ -9,8 +9,8 @@
 
 	$action = GETPOST('action', 'alpha');
 	$make_it = GETPOST('make_it', 'none');
-	$fk_product = GETPOST('fk_product', 'int');
-	$coef = GETPOST('coef', 'int');
+	$fk_product = (int)GETPOST('fk_product', 'int');
+	$coef = (double)GETPOST('coef', 'int');
 
 	$PDOdb = new TPDOdb;
 

--- a/massUpdate.php
+++ b/massUpdate.php
@@ -1,56 +1,56 @@
 <?php
 
 	require 'config.php';
-	
+
 	if(empty($user->rights->nomenclature->global->massUpdate))accessforbidden();
-	
+
 	dol_include_once('/product/class/product.class.php');
 	dol_include_once('/nomenclature/class/nomenclature.class.php');
-	
-	$action = GETPOST('action');
-	$make_it = GETPOST('make_it');
-	$fk_product = (int)GETPOST('fk_product');
-	$coef = (double)GETPOST('coef');
-	
+
+	$action = GETPOST('action', 'alpha');
+	$make_it = GETPOST('make_it', 'none');
+	$fk_product = GETPOST('fk_product', 'int');
+	$coef = GETPOST('coef', 'int');
+
 	$PDOdb = new TPDOdb;
-	
+
 	llxHeader();
 	dol_fiche_head();
 	print_fiche_titre($langs->trans('massUpdate'));
-	
+
 	$formCore = new TFormCore('auto','formN','post');
 	echo $formCore->hidden('action', 'update');
-	
+
 	$form->select_produits($fk_product, 'fk_product');
-	
+
 	echo $formCore->texte($langs->trans('PercentUP'), 'coef', $coef, 3).'%';
-	
+
 	echo '&nbsp;&nbsp;&nbsp;' . $formCore->btsubmit($langs->trans('ShowImpact'), 'bt_show');
-	
+
 	flush();
-	
+
 	if($action == 'update' && $fk_product>0) {
-		
+
 		$TCoef = TNomenclatureCoef::loadCoef($PDOdb);
-		
-		$Tab = $PDOdb->ExecuteAsArray("SELECT nd.rowid, n.fk_object, qty, product_type,code_type 
+
+		$Tab = $PDOdb->ExecuteAsArray("SELECT nd.rowid, n.fk_object, qty, product_type,code_type
 						FROM ".MAIN_DB_PREFIX."nomenclaturedet nd
 							LEFT JOIN ".MAIN_DB_PREFIX."nomenclature n ON (nd.fk_nomenclature = n.rowid)
 						WHERE nd.fk_product = ".$fk_product." AND n.object_type='product'");
-	
+
 		if(!empty($Tab)) {
-			
+
 			echo '<hr /><table class="border" width="100%">
 				<tr class="titre">
 					<td>'.$langs->trans('Product').'</td><td>'.$langs->trans('Type').'</td><td>'.$langs->trans('Qty').'</td><td>'.$langs->trans('QtyAfter').'</td></tr>';
-			
+
 			foreach($Tab as &$row) {
-				
+
 				$p=new Product($db);
-				
+
 				if($row->fk_object>0 && $p->fetch($row->fk_object)>0) {
 					$bc = (empty($bc) || $bc == 'pair') ? 'impair' : 'pair';
-					
+
 					echo '<tr class="'.$bc.'">
 						<td>'.$p->getNomUrl(1).'</td>
 						<td>'.$TCoef[$row->code_type]->label.'</td>
@@ -58,39 +58,39 @@
 						<td>'.price($row->qty * ( (100 +  $coef) / 100)  ).'</td>
 					</tr>
 					';
-					
-					
+
+
 				}
-				
-				
-				
-				
+
+
+
+
 			}
-			
-			
+
+
 			echo '</table>';
-			
+
 			if(empty($make_it)) {
-				
+
 				echo '<div class="tabsAction">'.$formCore->btsubmit($langs->trans('MakeIt'), 'make_it').'</div>';
-				
+
 			}
 			else{
-	
-					$res = $PDOdb->Execute(" UPDATE ".MAIN_DB_PREFIX."nomenclaturedet 
-								SET qty = qty * ( (100 +  ".$coef.") / 100) 
+
+					$res = $PDOdb->Execute(" UPDATE ".MAIN_DB_PREFIX."nomenclaturedet
+								SET qty = qty * ( (100 +  ".$coef.") / 100)
 								WHERE fk_product = ".$fk_product );
-								
+
 					echo '<div class="info">Mise à jour effectuée</div>';
-					
+
 			}
-			
+
 		}
-	
-		
+
+
 	}
-	
+
 	$formCore->end();
-	
+
 	dol_fiche_end();
 	llxFooter();

--- a/nomenclature-detail.php
+++ b/nomenclature-detail.php
@@ -15,14 +15,14 @@ if(! class_exists('TSubtotal')) dol_include_once('/subtotal/class/subtotal.class
 $langs->load('nomenclature@nomenclature');
 $langs->load('workstation@workstation');
 
-$object_type = GETPOST('object');
+$object_type = GETPOST('object', 'alpha');
 $id = GETPOST('id', 'int');
-$ref = GETPOST('ref');
+$ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'none', 2); // Check only $_POST
 
 $hookmanager->initHooks(array('nomenclatureproductservicelist'));
 
-if(GETPOST('save') == 'ok') setEventMessage($langs->trans('Saved'));
+if(GETPOST('save', 'none') == 'ok') setEventMessage($langs->trans('Saved'));
 
 $form = new Form($db);
 $PDOdb = new TPDOdb;

--- a/nomenclature-speed.php
+++ b/nomenclature-speed.php
@@ -2,14 +2,14 @@
 
 	require 'config.php';
 	dol_include_once('/nomenclature/class/nomenclature.class.php');
-	
-	$langs->load('nomenclature@nomenclature');
-	
-	$object_type = GETPOST('object');	
-	$id = (int)GETPOST('id');
 
-	if(GETPOST('save')=='ok') setEventMessage($langs->trans('Saved'));
-	
+	$langs->load('nomenclature@nomenclature');
+
+	$object_type = GETPOST('object', 'none');
+	$id = GETPOST('id', 'int');
+
+	if(GETPOST('save', 'alpha')=='ok') setEventMessage($langs->trans('Saved'));
+
 	if($object_type =='propal') {
 		dol_include_once('/comm/propal/class/propal.class.php');
 		$object = new Propal($db);
@@ -25,24 +25,24 @@
 	else {
 		exit('? object type ?');
 	}
-	
+
 	if(empty($object))exit;
 	$PDOdb=new TPDOdb;
 
 	$TProductAlreadyInPage=array();
-	
+
 	// redirrection sur une vue global non modifiable
 	if( ($object->fk_statut>0 || $object->statut>0) && in_array($object_type, array('propal','commande')) ) {
 	    $url = dol_buildpath('/nomenclature/nomenclature-detail.php' , 1).'?id='.$object->id.'&object='.$object_type;
 	    header('Location: '.$url);
 	    exit;
 	}
-	
+
 	_drawlines($object, $object_type);
-	
+
 function _drawHeader($object, $object_type) {
 global $db,$langs,$conf,$PDOdb;
-	
+
 	if($object_type == 'propal') {
 		dol_include_once('/core/lib/propal.lib.php');
 		$head = propal_prepare_head($object);
@@ -52,12 +52,12 @@ global $db,$langs,$conf,$PDOdb;
 		 * Propal synthese pour rappel
 		 */
 		print '<table class="border" width="100%">';
-	
+
 		// Ref
 		print '<tr><td width="25%">'.$langs->trans('Ref').'</td><td colspan="3">';
 		print $object->ref;
 		print '</td></tr>';
-		
+
 		// Ref client
 		print '<tr><td>';
 		print '<table class="nobordernopadding" width="100%"><tr><td class="nowrap">';
@@ -69,7 +69,7 @@ global $db,$langs,$conf,$PDOdb;
 		print '</td>';
 		print '</tr>';
 		print '</table>';
-		
+
 	}
 	else if($object_type == 'commande') {
                 dol_include_once('/core/lib/order.lib.php');
@@ -104,7 +104,7 @@ global $db,$langs,$conf,$PDOdb;
 	if($object->fk_statut>0 || $object->statut>0) {
 
 		echo '<div class="error">'. $langs->trans('StatusOfObjectAvoidEdit') .'</div>';
-		
+
 
 		llxFooter();
 		exit;
@@ -116,15 +116,15 @@ global $db,$langs,$conf,$PDOdb;
 		var fk_object=<?php echo $object->id; ?>;
 		var object_type="<?php echo $object_type; ?>";
 		var NOMENCLATURE_SPEED_CLICK_SELECT = <?php echo (int)$conf->global->NOMENCLATURE_SPEED_CLICK_SELECT; ?>;
-		
+
 		function editLine(fk_line) {
-	
-			url="<?php 
+
+			url="<?php
 				if((float) DOL_VERSION >= 4.0 && $object_type=='propal') echo dol_buildpath('/comm/propal/card.php?id='.$object->id,1);
 				elseif($object_type=='propal') echo dol_buildpath('/comm/propal.php?id='.$object->id,1);
 				else if($object_type=='commande')echo dol_buildpath('/commande/card.php?id='.$object->id,1);
-			?>&action=editline&lineid="+fk_line;	
-			
+			?>&action=editline&lineid="+fk_line;
+
 			$('div#dialog-edit-line').remove();
 			$('body').append('<div id="dialog-edit-line"></div>');
 			$('div#dialog-edit-line').dialog({
@@ -132,85 +132,85 @@ global $db,$langs,$conf,$PDOdb;
 				,width:"80%"
 				,modal:true
 			});
-				
+
 			$.ajax({
 				url:url
 			}).done(function(data) {
-				
+
 				$form = $(data).find('form#addproduct');
 				$form.find('input[name=cancel]').remove();
 				$form.find('tr[id]').not('#row-'+fk_line).remove();
-				
+
 				$form.submit(function() {
 					if (typeof CKEDITOR == "object" && typeof CKEDITOR.instances != "undefined" && CKEDITOR.instances['product_desc'] != "undefined") {
 						$form.find('textarea#product_desc').val(CKEDITOR.instances['product_desc'].getData());
 					}
-					
+
 					$.post($(this).attr('action'), $(this).serialize()+'&save=1', function() {
-						
+
 					});
-				
-					$('div#dialog-edit-line').dialog('close');			
-					
+
+					$('div#dialog-edit-line').dialog('close');
+
 					return false;
-			
-					
+
+
 				});
-				
+
 				$('div#dialog-edit-line').html($form);
 			});
-						
+
 		}
 	</script><?php
-	
+
 }
-	
+
 function _drawlines(&$object, $object_type) {
 	global $db,$langs,$conf,$PDOdb,$TProductAlreadyInPage;
-	
+
 	llxHeader('', 'Nomenclatures', '', '', 0, 0, array('/nomenclature/js/speed.js','/nomenclature/js/jquery-sortable-lists.min.js'), array('/nomenclature/css/speed.css'));
-	
+
 	_drawHeader($object, $object_type);
-	
+
 	$formDoli=new Form($db);
 	$formCore=new TFormCore;
 	echo '<div id="addto" style="float:right; width:200px;">';
-	
+
 		if(!empty($conf->global->NOMENCLATURE_ALLOW_JUST_MP)) {
 			print $formDoli->select_produits('', 'fk_product', '', 0,0,-1,0);
 		}
 		else{
 			print $formDoli->select_produits('', 'fk_product', '', 0,0,-1);
 		}
-	
+
 		echo $formCore->bt($langs->trans('AddProductNomenclature'), 'AddProductNomenclature');
 		echo '<hr />';
-		
+
 		echo $formCore->combo('', 'fk_new_workstation',TWorkstation::getWorstations($PDOdb, false, true), -1);
 		echo $formCore->bt($langs->trans('AddWorkstation'), 'AddWorkstation');
-		
+
 		echo '<hr />';
 		echo $formCore->bt($langs->trans('SaveAll'), 'SaveAll');
-		
+
 	echo '</div>';
-	
+
 	echo '<ul id="speednomenclature" container-type="main" class="lines '.$object->element.'">';
-	
+
 	foreach($object->lines as $k=>&$line) {
-		
+
 		if($line->product_type == 9) {
 			$class="lineObject special";
 			$line_type="special";
 		}
 		else {
 			$class="lineObject";
-			$line_type="line";	
+			$line_type="line";
 		}
 
 		echo '<li k="'.$k.'" class="'.$class.'" line-type="'.$line_type.'" object_type="'.$object->element.'" id="line-'.$line->id.'"  fk_object="'.$line->id.'" fk_product="'.$line->fk_product.'">';
-		
+
 		echo '<div>';
-		
+
 		if($line->product_type == 0 || $line->product_type == 1) {
 			echo '<a href="javascript:editLine('.$line->id.');" class="editline clicable">'.img_edit($langs->trans('EditLine')).'</a>';
 			if(!empty($conf->global->NOMENCLATURE_SPEED_CLICK_SELECT)) {
@@ -220,11 +220,11 @@ function _drawlines(&$object, $object_type) {
 			}
 		}
 		$label = !empty($line->label) ? $line->label : (empty($line->libelle) ? $line->desc : $line->libelle);
-		
+
 		if($line->fk_product>0) {
 			$product = new Product($db);
 			$product->fetch($line->fk_product);
-			
+
 			echo '<div class="label">'.$product->getNomUrl(1).' '.$product->label.'</div>';
 		}
 		else if($line->product_type == 9 ) {
@@ -234,49 +234,49 @@ function _drawlines(&$object, $object_type) {
 			//	var_dump($line);exit;
 			}
 			else {
-				echo '<div class="title label">'.$line->qty.'. '.$label.'</div>';	
+				echo '<div class="title label">'.$line->qty.'. '.$label.'</div>';
 			}
-			
-			
+
+
 		}
 		else {
 			/* ligne libre */
 			echo '<div class="free label">'.$label.'</div>';
 		}
-		
+
 		if($line->product_type == 0 || $line->product_type == 1) echo '<div class="qty"><input rel="qty" value="'.$line->qty.'" class="flat qty clicable" size="5" /></div>';
 
 		echo '</div>';
 
-		if($line->product_type == 0 || $line->product_type == 1) _drawnomenclature($line->id, $object->element,$line->fk_product,$line->qty);	
-		
-		echo '</li>';	
-		
-			
+		if($line->product_type == 0 || $line->product_type == 1) _drawnomenclature($line->id, $object->element,$line->fk_product,$line->qty);
+
+		echo '</li>';
+
+
 	}
 
 	echo '</ul>';
 	?>
 	<div class="logme"></div>
-	
+
 	<div style="text-align: left;">
-		<div class="inline-block divButAction"><a href="nomenclature-detail.php?id=<?php echo GETPOST('id') ?>&object=<?php echo GETPOST('object') ?>" class="butAction">Liste produits et MO nécessaires</a></div>
-		
+		<div class="inline-block divButAction"><a href="nomenclature-detail.php?id=<?php echo GETPOST('id', 'int') ?>&object=<?php echo GETPOST('object', 'none') ?>" class="butAction">Liste produits et MO nécessaires</a></div>
+
 	</div>
-	
+
 	<?php
 	dol_fiche_end();
 	llxFooter();
-} 
+}
 function _drawnomenclature($fk_object, $object_type,$fk_product,$qty, $level = 1) {
 	global $db,$langs,$conf,$PDOdb,$TProductAlreadyInPage;
-	
+
 	$max_nested_aff_level = empty($conf->global->NOMENCLATURE_MAX_NESTED_AFF_LEVEL) ? 7 : $conf->global->NOMENCLATURE_MAX_NESTED_AFF_LEVEL;
 	if($level > $max_nested_aff_level) {
 		echo '<div class="error">'.$langs->trans('ThereIsTooLevelHere').'</div>';
 		return false;
 	}
-	
+
 
 	$nomenclature=new TNomenclature;
 	$nomenclature->loadByObjectId($PDOdb, $fk_object, $object_type, true,$fk_product,$qty);
@@ -284,16 +284,16 @@ function _drawnomenclature($fk_object, $object_type,$fk_product,$qty, $level = 1
         echo 1;
 var_dump( $object_type,$fk_product,$qty , $nomenclature->TNomenclatureAll);
 }*/
-	
+
 	if(!empty($TProductAlreadyInPage[$fk_object.'_'. $object_type])) {
 		echo '<ul class="lines nomenclature" container-type="nomenclature" fk_nomenclature="'.$nomenclature->getId().'">';
 		echo '<li class="nomenclature clicable" no-hierarchie-parse="1" id="nomenclature-nouse-'.$nomenclature->getId().'-'.$fk_product.'">Nomenclature déjà affichée <a href="#" onclick="window.scrollTo(0, $(\'li[fk_object='.$fk_product.'][object_type=product]\').first().offset().top ); ">ici</a></li>';
 		echo '</ul>';
 	}
 	else if(!empty($nomenclature->TNomenclatureAll)) {
-		
+
 		$TProductAlreadyInPage[$fk_object.'_'. $object_type] = 1;
-		
+
 		if($nomenclature->iExist) {
 			echo '<ul class="lines nomenclature" container-type="nomenclature" fk_nomenclature="'.$nomenclature->getId().'">';
 		}
@@ -301,16 +301,16 @@ var_dump( $object_type,$fk_product,$qty , $nomenclature->TNomenclatureAll);
 			echo '<ul class="lines notanomenclature" container-type="nomenclature" fk_nomenclature="0" fk_original_nomenclature="'.$nomenclature->fk_nomenclature_parent.'">';
 			echo '<div>'.$langs->trans('PseudoNomenclature') .img_help('',$langs->trans('PseudoNomenclatureInfo')  ).'</div>';
 		}
-		
+
 		foreach($nomenclature->TNomenclatureAll as $k=>&$line) {
-			
+
 			if(get_class($line) === 'TNomenclatureDet' ) {
-				
+
 				$product = new Product($db);
 				if($line->fk_product>0 && $product->fetch($line->fk_product)>0) {
 					$id = $line->getId() > 0 ? $line->getId() : $nomenclature->fk_nomenclature_parent.'-'.$k;
-				
-				
+
+
 					echo '<li class="nomenclature" k="'.$k.'" line-type="nomenclature" id="nomenclature-product-'.$id.'" object_type="product" fk_object="'.$line->fk_product.'">';
 					echo '<div class="clicable" rel="delete">'.img_delete('',' class="clicable"').'</div>';
 					if(!empty($conf->global->NOMENCLATURE_SPEED_CLICK_SELECT)) {
@@ -323,12 +323,12 @@ var_dump( $object_type,$fk_product,$qty , $nomenclature->TNomenclatureAll);
 						echo '<div class="qty"><input rel="qty" value="'.$line->qty.'" class="flat qty clicable" size="5" />';
 						if($qty > 1) echo '&nbsp;(x '.$qty.')';
 						echo '</div>';
-						
+
 					echo '</div>';
-						_drawnomenclature($product->id, 'product',$product->id,$line->qty * $qty,$level+1);		
+						_drawnomenclature($product->id, 'product',$product->id,$line->qty * $qty,$level+1);
 					echo '</li>';
 				}
-				
+
 			}
 			else {
 				echo '<li class="nomenclature workstation" line-type="workstation"  k="'.$k.'" object_type="workstation" id="nomenclature-ws-'.$line->getId().'" fk_object="'.$line->workstation->getId().'">';
@@ -343,12 +343,12 @@ var_dump( $object_type,$fk_product,$qty , $nomenclature->TNomenclatureAll);
 				</div>';
 				echo '</li>';
 			}
-			
+
 		}
-	
+
 		echo '</ul>';
 	}
 
 	return true;
-	
+
 }

--- a/nomenclature.php
+++ b/nomenclature.php
@@ -27,14 +27,14 @@ $fk_product = GETPOST('fk_product', 'int');
 $product_ref = GETPOST('ref', 'alpha');
 if ($fk_product || $product_ref) $product->fetch($fk_product, $product_ref);
 
-$qty_ref = GETPOST('qty_ref', 'int'); // il s'agit de la qty de la ligne de document, si vide alors il faudra utiliser qty_reference de la nomenclature
+$qty_ref = (float)GETPOST('qty_ref', 'int'); // il s'agit de la qty de la ligne de document, si vide alors il faudra utiliser qty_reference de la nomenclature
 
 $action= GETPOST('action', 'alpha');
 
 $PDOdb=new TPDOdb;
 
-$fk_object=GETPOST('fk_object', 'int');
-$fk_nomenclature=GETPOST('fk_nomenclature', 'int');
+$fk_object= (int)GETPOST('fk_object', 'int');
+$fk_nomenclature= (int)GETPOST('fk_nomenclature', 'int');
 $object_type = GETPOST('object_type', 'none');
 $fk_origin = GETPOST('fk_origin', 'int');
 
@@ -68,7 +68,7 @@ if (empty($reshook))
 
 	if($action==='delete_nomenclature') {
 	    $n=new TNomenclature;
-	    $n->load($PDOdb, GETPOST('fk_nomenclature', 'int'));
+	    $n->load($PDOdb, (int)GETPOST('fk_nomenclature', 'int'));
 	    $n->delete($PDOdb);
 
 	    setEventMessage('NomenclatureDeleted');
@@ -113,7 +113,7 @@ if (empty($reshook))
 	    $n->load($PDOdb, $fk_nomenclature);
 
 	    if($n->getId()>0) {
-	    	$k = GETPOST('k', 'int');
+	    	$k = (int)GETPOST('k', 'int');
 	//var_dump( $fk_nomenclature,$k,$n->TNomenclatureWorkstation);
 		$n->TNomenclatureWorkstation[$k]->to_delete = true;
 		$n->save($PDOdb);
@@ -127,7 +127,7 @@ if (empty($reshook))
 			$n->load($PDOdb, $fk_nomenclature);
 			$n->delete($PDOdb);
 
-			$res = cloneNomenclatureFromProduct($PDOdb, GETPOST('fk_clone_from_product', 'int'), $fk_object, $object_type);
+			$res = cloneNomenclatureFromProduct($PDOdb, (int)GETPOST('fk_clone_from_product', 'int'), $fk_object, $object_type);
 
 		}
 		else
@@ -144,7 +144,7 @@ if (empty($reshook))
 
 			$n->set_values($_POST);
 
-		    $n->is_default = GETPOST('is_default', 'int');
+		    $n->is_default = (int)GETPOST('is_default', 'int');
 
 			if($n->is_default>0) TNomenclature::resetDefaultNomenclature($PDOdb, $n->fk_product);
 
@@ -211,7 +211,7 @@ if (empty($reshook))
 		    $n->save($PDOdb);
 
 			// Fait l'update du PA et PU de la ligne si nécessaire
-			_updateObjectLine($n, $object_type, $fk_object, GETPOST('fk_origin', 'int'), GETPOST('apply_nomenclature_price', 'none'));
+			_updateObjectLine($n, $object_type, $fk_object, (int)GETPOST('fk_origin', 'int'), GETPOST('apply_nomenclature_price', 'none'));
 
 			if(empty($disableAnchorRedirection)){
 				header("Location: ".$_SERVER["PHP_SELF"].'?fk_product='.intval($fk_product)."&fk_nomenclature=".$n->id.$anchorTag);
@@ -249,7 +249,7 @@ if (empty($reshook))
 if($object_type != 'product') {
 
     $langs->load('nomenclature@nomenclature');
-    $origin_object_id = GETPOST('fk_origin', 'int');
+    $origin_object_id = (int)GETPOST('fk_origin', 'int');
     $n=new TNomenclature;
     $n->loadByObjectId($PDOdb,$fk_object, $object_type, false, $product->id, $qty_ref, $origin_object_id);
     $readonly = $object->statut > 0;
@@ -354,7 +354,7 @@ function _show_product_nomenclature(&$PDOdb, &$product, &$object) {
 
 
 	    // open if edited
-	    $fk_nomenclature=GETPOST('fk_nomenclature', 'int');
+	    $fk_nomenclature=(int)GETPOST('fk_nomenclature', 'int');
 
 	    // default open
 	    if(!empty($n->is_default) && empty($fk_nomenclature)){
@@ -451,7 +451,7 @@ function get_format_libelle_produit($fk_product = null) {
 function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $object_type='product', $qty_ref=1, $readonly=false) {
 	global $langs, $conf, $db, $user, $hookmanager;
 
-	$coef_qty_price = $n->setPrice($PDOdb,$qty_ref,$fk_object,$object_type,GETPOST('fk_origin', 'int'));
+	$coef_qty_price = $n->setPrice($PDOdb,$qty_ref,$fk_object,$object_type,(int)GETPOST('fk_origin', 'int'));
 
 
 

--- a/nomenclature_coef.php
+++ b/nomenclature_coef.php
@@ -20,11 +20,11 @@ if(GETPOST('deleteSpecific', 'none')) {
 	{
 		require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 		$object = new Propal($db);
-		$object->fetch(GETPOST('id', 'int'));
+		$object->fetch((int)GETPOST('id', 'int'));
 		TNomenclatureWorkstationThmObject::deleteAllThmObject($PDOdb, $object->id, $object->element);
 	}
 
-	TNomenclatureCoefObject::deleteCoefsObject($PDOdb, GETPOST('id', 'int'), $fiche);
+	TNomenclatureCoefObject::deleteCoefsObject($PDOdb, (int)GETPOST('id', 'int'), $fiche);
 
 	// Si je supprime les coef custom, alors je dois ré-appliquer en automatique les prix de vente (sinon ça veut dire qu'on laisse la possibilité de supprimer les coef et de garder des montants lignes incohérents)
 	if ($fiche == 'propal') _updateLinePriceObject($PDOdb, $db, $conf, $langs, $user, 'propal');
@@ -57,7 +57,7 @@ switch ($fiche) {
 			if (!empty($conf->global->NOMENCLATURE_USE_CUSTOM_THM_FOR_WS))
 			{
 				$object = new Propal($db);
-				$object->fetch(GETPOST('id', 'int'));
+				$object->fetch((int)GETPOST('id', 'int'));
 
 				$TNomenclatureWorkstationThmObject = GETPOST('TNomenclatureWorkstationThmObject', 'none');
 				TNomenclatureWorkstationThmObject::updateAllThmObject($PDOdb, $object, $TNomenclatureWorkstationThmObject);

--- a/nomenclature_coef.php
+++ b/nomenclature_coef.php
@@ -15,16 +15,16 @@ $parameters = array('fiche' => $fiche);
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 
-if(GETPOST('deleteSpecific')) {
+if(GETPOST('deleteSpecific', 'none')) {
 	if (!empty($conf->global->NOMENCLATURE_USE_CUSTOM_THM_FOR_WS) && $fiche == 'propal')
 	{
 		require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 		$object = new Propal($db);
-		$object->fetch(GETPOST('id'));
+		$object->fetch(GETPOST('id', 'int'));
 		TNomenclatureWorkstationThmObject::deleteAllThmObject($PDOdb, $object->id, $object->element);
 	}
 
-	TNomenclatureCoefObject::deleteCoefsObject($PDOdb, GETPOST('id'), $fiche);
+	TNomenclatureCoefObject::deleteCoefsObject($PDOdb, GETPOST('id', 'int'), $fiche);
 
 	// Si je supprime les coef custom, alors je dois ré-appliquer en automatique les prix de vente (sinon ça veut dire qu'on laisse la possibilité de supprimer les coef et de garder des montants lignes incohérents)
 	if ($fiche == 'propal') _updateLinePriceObject($PDOdb, $db, $conf, $langs, $user, 'propal');
@@ -57,15 +57,15 @@ switch ($fiche) {
 			if (!empty($conf->global->NOMENCLATURE_USE_CUSTOM_THM_FOR_WS))
 			{
 				$object = new Propal($db);
-				$object->fetch(GETPOST('id'));
+				$object->fetch(GETPOST('id', 'int'));
 
-				$TNomenclatureWorkstationThmObject = GETPOST('TNomenclatureWorkstationThmObject');
+				$TNomenclatureWorkstationThmObject = GETPOST('TNomenclatureWorkstationThmObject', 'none');
 				TNomenclatureWorkstationThmObject::updateAllThmObject($PDOdb, $object, $TNomenclatureWorkstationThmObject);
 			}
 
 			_updateCoef($PDOdb, $db, $conf, $langs, $user);
 
-			if (GETPOST('update_line_price')) _updateLinePriceObject($PDOdb, $db, $conf, $langs, $user, 'propal');
+			if (GETPOST('update_line_price', 'none')) _updateLinePriceObject($PDOdb, $db, $conf, $langs, $user, 'propal');
 
 			header('Location: '.dol_buildpath('/nomenclature/nomenclature_coef.php?id='.GETPOST('id', 'int').'&fiche=propal', 1));
 			exit;
@@ -270,7 +270,7 @@ function _updateCoef(&$PDOdb, &$db, &$conf, &$langs, &$user)
 	$fk_object = GETPOST('id', 'int');
 	$type_object = GETPOST('fiche', 'alpha');
 
-	$TNomenclatureCoefObject = GETPOST('TNomenclatureCoefObject');
+	$TNomenclatureCoefObject = GETPOST('TNomenclatureCoefObject', 'none');
 //	var_dump($TNomenclatureCoefObject);exit;
 	if (!empty($TNomenclatureCoefObject))
 	{

--- a/nomenclature_coef_product.php
+++ b/nomenclature_coef_product.php
@@ -1,6 +1,6 @@
 <?php
 /* Copyright (C) 2014 Alexis Algoud        <support@atm-conuslting.fr>
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or
@@ -31,7 +31,7 @@ dol_include_once('/nomenclature/class/nomenclature.class.php');
 $type_object = 'product';
 
 // GET POST
-$id = (int)GETPOST('id');
+$id = GETPOST('id', 'int');
 $action=GETPOST('action','alpha');
 
 // Load translation files required by the page
@@ -77,13 +77,13 @@ if (empty($reshook))
     if ($action == 'add' || $action == 'edit')
     {
         $idCoef = GETPOST('rowid', 'int');
-        
-        if (GETPOST('delete'))
+
+        if (GETPOST('delete', 'alpha'))
         {
             $nomenclatureCoef = new TNomenclatureCoefObject;
             $nomenclatureCoef->load($PDOdb, $idCoef);
             $res = $nomenclatureCoef->delete($PDOdb);
-            
+
             if ($res > 0) setEventMessages($langs->trans('NomenclatureDeleteSuccess'), null);
             else setEventMessages($langs->trans('NomenclatureErrorCantDelete'), null, 'errors');
         }
@@ -93,24 +93,24 @@ if (empty($reshook))
             $desc = GETPOST('desc', 'alpha');
             $code = GETPOST('code_type', 'alpha');
             $tx = GETPOST('tx', 'alpha');
-            
+
             if ($code && $tx)
             {
                 $nomenclatureCoef = new TNomenclatureCoefObject;
-                
+
                 if ($idCoef) $nomenclatureCoef->load($PDOdb, $idCoef);
-                else $nomenclatureCoef->type = GETPOST('line_type');
-                
-                
+                else $nomenclatureCoef->type = GETPOST('line_type', 'none');
+
+
                 $nomenclatureCoef->fk_object = $object->id;
                 $nomenclatureCoef->type_object = $type_object;
                 //$nomenclatureCoef->label = $label;
                 //$nomenclatureCoef->description = $desc;
                 $nomenclatureCoef->code_type = $code;
                 $nomenclatureCoef->tx_object = $tx;
-                
+
                 $rowid = $nomenclatureCoef->save($PDOdb);
-                
+
                 if ($rowid) setEventMessages($langs->trans('NomenclatureSuccessSaveCoef'), null);
                 else setEventMessages($langs->trans('NomenclatureErrorAddCoefDoublon'), null, 'errors');
             }
@@ -119,27 +119,27 @@ if (empty($reshook))
                 setEventMessages($langs->trans('NomenclatureErrorAddCoef'), null, 'errors');
             }
         }
-        
+
     }
-    
+
 }
 
 
 
 /*
- * View 
+ * View
  */
 
 
 $title = $langs->trans('ProductServiceCard');
 $helpurl = '';
 $shortlabel = dol_trunc($object->label,16);
-if (GETPOST("type") == '0' || ($object->type == Product::TYPE_PRODUCT))
+if (GETPOST("type", 'none') == '0' || ($object->type == Product::TYPE_PRODUCT))
 {
     $title = $langs->trans('Product')." ". $shortlabel ." - ".$langs->trans('CoefList');
     $helpurl='EN:Module_Products|FR:Module_Produits|ES:M&oacute;dulo_Productos';
 }
-if (GETPOST("type") == '1' || ($object->type == Product::TYPE_SERVICE))
+if (GETPOST("type", 'none') == '1' || ($object->type == Product::TYPE_SERVICE))
 {
     $title = $langs->trans('Service')." ". $shortlabel ." - ".$langs->trans('CoefList');
     $helpurl='EN:Module_Services_En|FR:Module_Services|ES:M&oacute;dulo_Servicios';
@@ -170,7 +170,7 @@ print '<div class="fichecenter" >';
 
 $TCoef = TNomenclatureCoefObject::loadCoefObject($PDOdb, $object, $type_object);
 
-$num = !empty($TCoef)?count($TCoef):''; 
+$num = !empty($TCoef)?count($TCoef):'';
 
 $backbutton = '';
 print_barre_liste($langs->trans("DefaultCoeficientList"), 0, $_SERVER["PHP_SELF"], '', '', '', $backbutton, $num, $num);
@@ -215,13 +215,13 @@ print '<td align="center" ></td>'."\n";
 
 foreach ($TCoef as $coef)
 {
-    
+
     $allow_to_delete = false;
     if( $coef->code_type!='coef_marge' || ($coef->code_type!='coef_marge' && $coef->rowid > 1) ){
         $allow_to_delete = true;
     }
-    
-    
+
+
     $var=!$var;
     print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
     print '<tr '.$bc[$var].'>';
@@ -229,22 +229,22 @@ foreach ($TCoef as $coef)
     print '<td align="center" width="20">';
     print '<input readonly="readonly" type="hidden" name="code_type" value="'.$coef->code_type.'"  size="15" />'.$coef->code_type;
     print '</td>';
-    
+
     print '<td align="center" >';
-    
+
     print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
     print '<input type="hidden" name="action" value="edit">';
     print '<input type="hidden" name="id" value="'.$object->id.'">';
     print '<input type="hidden" name="type_object" value="'.$type_object.'">';
     print '<input type="hidden" name="rowid" value="'.$coef->rowid.'">';
     print '<input type="text" name="tx" value="'.$coef->tx.'"  size="5" />&nbsp;&nbsp;';
-    
+
     print '</td>';
     print '<td align="right" >';
-    
+
     print '<input type="submit" class="button" name="edit" value="'.$langs->trans("Modify").'">&nbsp;';
     if($allow_to_delete) print '<input type="submit" class="button" name="delete" value="'.$langs->trans("Delete").'">';
-    
+
     print '</td></tr>';
     print '</form>';
 }

--- a/nomenclature_coef_product.php
+++ b/nomenclature_coef_product.php
@@ -31,7 +31,7 @@ dol_include_once('/nomenclature/class/nomenclature.class.php');
 $type_object = 'product';
 
 // GET POST
-$id = GETPOST('id', 'int');
+$id = (int)GETPOST('id', 'int');
 $action=GETPOST('action','alpha');
 
 // Load translation files required by the page

--- a/prod_ajax.php
+++ b/prod_ajax.php
@@ -1,6 +1,6 @@
 <?php
 
-/* 
+/*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
@@ -10,18 +10,18 @@ require 'config.php';
 dol_include_once('/nomenclature/class/nomenclature.class.php');
 
 $PDOdb = new TPDOdb;
-if(GETPOST('action'))
+if(GETPOST('action', 'alpha'))
 	{
-		$action = GETPOST('action');
-		
-		
+		$action = GETPOST('action', 'alpha');
+
+
 		if($action == 'idprod_change')
 		{
-			$fk_product= (int)GETPOST('fk_product');
+			$fk_product= GETPOST('fk_product', 'int');
 			$nomenclature = new TNomenclature();
 			$nomenclature->loadByObjectId($PDOdb, $fk_product, 'product');
-			
-			
+
+
 			if($nomenclature->iExist)
 			{
 				$data['result'] = 1;

--- a/prod_ajax.php
+++ b/prod_ajax.php
@@ -17,7 +17,7 @@ if(GETPOST('action', 'alpha'))
 
 		if($action == 'idprod_change')
 		{
-			$fk_product= GETPOST('fk_product', 'int');
+			$fk_product= (int)GETPOST('fk_product', 'int');
 			$nomenclature = new TNomenclature();
 			$nomenclature->loadByObjectId($PDOdb, $fk_product, 'product');
 

--- a/script/interface.php
+++ b/script/interface.php
@@ -23,7 +23,7 @@ function _get(&$PDOdb, $case) {
 
             break;
         case 'categories':
-            $fk_parent = GETPOST('fk_parent', 'int');
+            $fk_parent = (int)GETPOST('fk_parent', 'int');
             $keyword= GETPOST('keyword', 'none');
 
             dol_include_once('/categories/class/categorie.class.php');
@@ -53,7 +53,7 @@ function _put(&$PDOdb, $case) {
             break;
 		case 'nomenclatures':
 
-			_putHierarchie($PDOdb,GETPOST('THierarchie', 'array'),GETPOST('fk_object', 'int'),GETPOST('object_type', 'alpha'));
+			_putHierarchie($PDOdb,GETPOST('THierarchie', 'array'),(int)GETPOST('fk_object', 'int'),GETPOST('object_type', 'alpha'));
 
 			break;
 		case 'rang':
@@ -64,7 +64,7 @@ function _put(&$PDOdb, $case) {
 
         case 'set-marge-final':
 
-            _setMargeFinal($PDOdb, GETPOST('code_type', 'none'), GETPOST('nomenclature_id', 'int'));
+            _setMargeFinal($PDOdb, GETPOST('code_type', 'none'), (int)GETPOST('nomenclature_id', 'int'));
             print 1;
             break;
 

--- a/script/interface.php
+++ b/script/interface.php
@@ -8,85 +8,85 @@
 
     $PDOdb = new TPDOdb;
 
-    $get = GETPOST('get');
-    $put = GETPOST('put');
-    
+    $get = GETPOST('get', 'none');
+    $put = GETPOST('put', 'none');
+
     _get($PDOdb,$get);
     _put($PDOdb,$put);
-    
+
 function _get(&$PDOdb, $case) {
-    
+
     switch ($case) {
         case 'nomenclature-line':
-            
+
             __out(_get_nomenclature_line());
-            
+
             break;
         case 'categories':
-            $fk_parent = (int)GETPOST('fk_parent');
-            $keyword= GETPOST('keyword');
-            
+            $fk_parent = GETPOST('fk_parent', 'int');
+            $keyword= GETPOST('keyword', 'none');
+
             dol_include_once('/categories/class/categorie.class.php');
             dol_include_once('/product/class/product.class.php');
-            
+
             $Tab =array(
                 'TCategory'=>_categories($fk_parent, $keyword)
                 ,'TProduct'=>_products($fk_parent)
             );
-            
+
             $Tab['default_price_level'] = 1;
-            
+
             __out($Tab,'json');
-            
+
             break;
         case 'coefs':
-            print json_encode(getAllCoefs(GETPOST('fk_line', 'int'), GETPOST('element')));
+            print json_encode(getAllCoefs(GETPOST('fk_line', 'int'), GETPOST('element', 'none')));
             break;
     }
-    
+
 }
 function _put(&$PDOdb, $case) {
-    
+
     switch ($case) {
         case 'nomenclature-line':
-            
+
             break;
 		case 'nomenclatures':
-			
-			_putHierarchie($PDOdb,GETPOST('THierarchie'),GETPOST('fk_object'),GETPOST('object_type'));
-			
+
+			_putHierarchie($PDOdb,GETPOST('THierarchie', 'array'),GETPOST('fk_object', 'int'),GETPOST('object_type', 'alpha'));
+
 			break;
 		case 'rang':
-			
-			_setRang($PDOdb, GETPOST('TRank'),GETPOST('type'));
-			
+
+			_setRang($PDOdb, GETPOST('TRank', 'array'),GETPOST('type', 'alpha'));
+
 			break;
 
         case 'set-marge-final':
 
-            _setMargeFinal($PDOdb, GETPOST('code_type'), GETPOST('nomenclature_id'));
+            _setMargeFinal($PDOdb, GETPOST('code_type', 'none'), GETPOST('nomenclature_id', 'int'));
             print 1;
             break;
 
     }
-    
+
 }
 
 function _setRang(&$PDOdb, $TRank,$type) {
-	
+
 	foreach($TRank as $k=>$id) {
-		
+
 		if($type == 'det') $o=new TNomenclatureDet;
 		else $o=new TNomenclatureWorkstation;
-		
+
 		$o->load($PDOdb, $id);
 		$o->rang = $k;
 		if(empty($o->unifyRang)) $o->unifyRang = $o->rang;
-		
+
 		$o->save($PDOdb);
-		
+
 	}
-	
+
 }
 
 function _setMargeFinal(&$PDOdb, $code_type, $nomenclature_id) {
@@ -100,13 +100,13 @@ function _setMargeFinal(&$PDOdb, $code_type, $nomenclature_id) {
 
 function _products($fk_parent=0) {
     global $db,$conf,$langs;
-    
+
     if(empty($fk_parent)) return array();
-    
+
     $parent = new Categorie($db);
     $parent->fetch($fk_parent);
     $TProd = $parent->getObjectsInCateg('product');
-    
+
     if (!empty($conf->global->SPC_DISPLAY_DESC_OF_PRODUCT))
     {
         require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
@@ -118,20 +118,20 @@ function _products($fk_parent=0) {
             $o->unit = $langs->trans($unit);
         }
     }
-    
+
     return $TProd;
 }
 
 function _get_nomenclature_line() {
-	
-	
-	
+
+
+
 }
 
 function _putHierarchieNomenclature(&$PDOdb, $THierarchie,$fk_object=0,$object_type='') {
-	
+
 	print 'HIERARCHIE ('.$fk_object.','.$object_type.')<br />';
-	
+
 	if($object_type!='') {
 		$nomenclature=new TNomenclature;
 		if(!$nomenclature->loadByObjectId($PDOdb, $fk_object, $object_type)) {
@@ -139,7 +139,7 @@ function _putHierarchieNomenclature(&$PDOdb, $THierarchie,$fk_object=0,$object_t
 			$nomenclature->object_type = $object_type;
 		}
 	}
-	
+
 	if(!empty($nomenclature->TNomenclatureDet)) {
 		foreach($nomenclature->TNomenclatureDet as &$det) {
 			$det->to_delete = true;
@@ -150,24 +150,24 @@ function _putHierarchieNomenclature(&$PDOdb, $THierarchie,$fk_object=0,$object_t
 			$det->to_delete = true;
 		}
 	}
-	
+
 
 	foreach($THierarchie as $kUnify=>&$line) {
-		
+
 		if(!empty($line['dontuse'])) return false; // ne pas traiter
-		
-		$k = $line['order'];	
+
+		$k = $line['order'];
 		if($line['object_type'] == 'product') {
 			if(empty($nomenclature->TNomenclatureDet[$k])) {
 				$nomenclature->TNomenclatureDet[$k]=new TNomenclatureDet;
-				
+
 			}
 			$nomenclature->TNomenclatureDet[$k]->to_delete = false;
 			$nomenclature->TNomenclatureDet[$k]->fk_product = $line['fk_object'];
 			$nomenclature->TNomenclatureDet[$k]->unifyRang = $kUnify;
 			//print $nomenclature->getid()."/$kUnify det <br />";
 			if(isset($line['qty'])) $nomenclature->TNomenclatureDet[$k]->qty = $line['qty'];
-			
+
 		}
 		else if($line['object_type'] == 'workstation') {
 			if(empty($nomenclature->TNomenclatureWorkstation[$k])) {
@@ -180,8 +180,8 @@ function _putHierarchieNomenclature(&$PDOdb, $THierarchie,$fk_object=0,$object_t
 			if(isset($line['nb_hour_manufacture'])) {
 				$nomenclature->TNomenclatureWorkstation[$k]->nb_hour_manufacture = $line['nb_hour_manufacture'];
 				$nomenclature->TNomenclatureWorkstation[$k]->nb_hour_prepare = $line['nb_hour_prepare'];
-			} 
-			
+			}
+
 		}
 
 		if($line['object_type'] != 'workstation') _putHierarchieNomenclature($PDOdb, empty($line['children']) ? array() : $line['children'],$line['fk_object'],$line['object_type']);
@@ -189,16 +189,16 @@ function _putHierarchieNomenclature(&$PDOdb, $THierarchie,$fk_object=0,$object_t
 	}
 	/*if($fk_object == 11) {
 		var_dump($THierarchie,$nomenclature);exit;
-		
-		
+
+
 	}*/
-	
+
 	if(isset($nomenclature)
-	 && ($nomenclature->TNomenclatureDet!=$nomenclature->TNomenclatureDetOriginal || $nomenclature->TNomenclatureWorkstation!=$nomenclature->TNomenclatureWorkstationOriginal) 
+	 && ($nomenclature->TNomenclatureDet!=$nomenclature->TNomenclatureDetOriginal || $nomenclature->TNomenclatureWorkstation!=$nomenclature->TNomenclatureWorkstationOriginal)
 	 ) {
 	 /*	if($fk_object == 3 && $object_type=='product') {
 		var_dump($nomenclature->TNomenclatureDet!=$nomenclature->TNomenclatureDetOriginal);
-		
+
 		var_dump($nomenclature);
 	}*/
 	//	$PDOdb->debug=true;
@@ -209,24 +209,24 @@ function _putHierarchieNomenclature(&$PDOdb, $THierarchie,$fk_object=0,$object_t
 
 function _putHierarchie(&$PDOdb, $THierarchie,$fk_object=0,$object_type='') {
 	global $db;
-	
+
 	dol_include_once('/comm/propal/class/propal.class.php');
 	dol_include_once('/commande/class/commande.class.php');
-	
+
 	if($object_type=='propal') $o=new Propal($db);
-	else if($object_type=='commande') $o=new Commande($db);	
-	
+	else if($object_type=='commande') $o=new Commande($db);
+
 	$o->fetch($fk_object);
-	
+
 	foreach($THierarchie as &$line) {
-		
+
 		$type = $line['object_type'];
 		$fk_line = $line['fk_object'];
 		$order = $line['order'];
-		
+
 		if($type=='propal') $table = 'propaldet';
 		else if($type=='commande') $table = 'commandedet';
-		
+
 		foreach($o->lines as &$l) {
 
 			if($l->id == $fk_line) {
@@ -234,24 +234,24 @@ function _putHierarchie(&$PDOdb, $THierarchie,$fk_object=0,$object_type='') {
 				print 'UPDATE line-rank('.$fk_line.') : '.$order.'</br >';
 				// propal, TODO commande
 				if($l->product_type == 9) {
-					null;					
+					null;
 				}
 				else {
 					$o->updateline($fk_line, $l->subprice, $line['qty'], $l->remise_percent, $l->tva_tx, $l->localtax1_tx, $l->localtax2_tx, $l->desc, 'HT'
 					, $l->info_bits, $l->special_code, $l->fk_parent_line, 0, $l->fk_fournprice, $l->pa_ht, $l->label, $l->product_type, $l->date_start
-					, $l->date_end, $l->array_options, $l->fk_unit);					
-					
+					, $l->date_end, $l->array_options, $l->fk_unit);
+
 				}
-			}			
-			
+			}
+
 		}
-		
+
 	}
-	
-	
+
+
 	_putHierarchieNomenclature($PDOdb,$THierarchie,$fk_object,$object_type);
-	
-	
+
+
 }
 
 
@@ -272,16 +272,16 @@ function _categories($fk_parent=0, $keyword='') {
             if(empty($conf->global->SPC_DO_NOT_LOAD_PARENT_CAT)) {
                 $TFille = $parent->get_all_categories(0,true);
             }
-            
+
         }
         else {
             $parent->fetch($fk_parent);
             $TFille = $parent->get_filles();
         }
-        
+
     }
-    
-    
+
+
     return $TFille;
 }
 

--- a/tab_project_feedback.php
+++ b/tab_project_feedback.php
@@ -33,7 +33,7 @@ dol_include_once('/comm/propal/class/propal.class.php');
 dol_include_once('/nomenclature/lib/nomenclature.lib.php');
 
 // GET POST
-$id = GETPOST('id', 'int');
+$id = (int)GETPOST('id', 'int');
 $action=GETPOST('action','alpha');
 
 $TQty = GETPOST('qty', 'array');

--- a/tab_project_feedback.php
+++ b/tab_project_feedback.php
@@ -33,7 +33,7 @@ dol_include_once('/comm/propal/class/propal.class.php');
 dol_include_once('/nomenclature/lib/nomenclature.lib.php');
 
 // GET POST
-$id = (int)GETPOST('id');
+$id = GETPOST('id', 'int');
 $action=GETPOST('action','alpha');
 
 $TQty = GETPOST('qty', 'array');


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.