### PR TITLE
Fetch_object juste lors de l'action "addline"

### DIFF
--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -139,7 +139,7 @@ class Actionsnomenclature
 		if (in_array('propalcard', $TContext) || in_array('ordercard', $TContext))
 		{
 
-            $ret = $object->fetch($object->id); // Reload to get new records
+			if($action == 'addline') $object->fetch($object->id); // Reload to get new records
 			// Ensure third party is loaded
 			if ($object->socid && empty($object->thirdparty)) $object->fetch_thirdparty();
 


### PR DESCRIPTION
**FIX Vue Archive Proposition Commercial : perte de données**

Lorsqu'on visualise l'archive d'une proposition commercial, le module nomenclature re fetch l'objet et écrase les données préalablement récupérées dans le hook "formObjectOptions"

Ce "fetch_object" a été ajouté par moi-même pour résoudre un bug lors de l'ajout de ligne, j'ai donc fait en sorte que celui-ci ne se fasse que dans ce cas là.