### PR TITLE
Bloquer la possibilité d'ajouter le produit sur sa propre nomenclature

### DIFF
--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -477,7 +477,9 @@ class TNomenclature extends TObjetStd
 	 * @return bool
 	 */
 	function addProduct($PDOdb, $fk_new_product, $fk_new_product_qty = 1) {
-        global $conf;
+        global $conf, $langs;
+
+        if($fk_new_product == $this->fk_object && $this->object_type = 'product' ) return false;
 
 		$k = $this->addChild($PDOdb, 'TNomenclatureDet');
         $det = &$this->TNomenclatureDet[$k];
@@ -499,9 +501,6 @@ class TNomenclature extends TObjetStd
 				return $det->rowid;
 		}
 		else {
-
-			    global $langs;
-
 			    setEventMessage($langs->trans('CantAddProductBecauseOfAnInfiniteLoop', 'errors'));
 
 			    $det->to_delete = true;

--- a/nomenclature.php
+++ b/nomenclature.php
@@ -172,12 +172,20 @@ if (empty($reshook))
 		    $fk_new_product = GETPOST('fk_new_product_'.$n->getId());
 		    $fk_new_product_qty = GETPOST('fk_new_product_qty_'.$n->getId());
 		    if(GETPOST('add_nomenclature') && $fk_new_product>0) {
-		    	$res = $n->addProduct($PDOdb, $fk_new_product, $fk_new_product_qty);
-		    	if(empty($res)) {
+
+				$last_det = end($n->TNomenclatureDet);
+				$url = dol_buildpath('nomenclature/nomenclature.php', 2).'?fk_product='.$n->fk_object.'&fk_nomenclature='.$n->getId().'#line_'.(intval($last_det->rowid));
+				$res = $n->addProduct($PDOdb, $fk_new_product, $fk_new_product_qty);
+
+				if(empty($res)) {
 					$p_err= new Product($db);
 					$p_err->fetch($fk_new_product);
 
 					setEventMessage($langs->trans('ThisProductCreateAnInfinitLoop').' '.$p_err->getNomUrl(0),'errors');
+
+					header("location: ".$url, true);
+					exit;
+
 				} elseif ($n->object_type === 'product') {
                     $last_det = end($n->TNomenclatureDet);
                     $url = dol_buildpath('nomenclature/nomenclature.php', 2).'?fk_product='.$n->fk_object.'&fk_nomenclature='.$n->getId().'#line_'.(intval($last_det->rowid));


### PR DESCRIPTION
#FIX : erreur lorsqu'on ajoute le produit sur sa propre nomenclature

Lorsqu'on ajoute le produit lui-même sur sa propre nomenclature, aucun blocage n'est prévu : cela créé une boucle infinie.

J'affiche un message d'erreur lorsque c'est le cas.