### PR TITLE
3.2 fix import setup columns order

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- FIX : import setup - columns order *2021-08-25* - 3.2.4
 - FIX : missing en_US translations. *2021-04-21* - 3.2.3
 
 ### 3.2

--- a/admin/import.php
+++ b/admin/import.php
@@ -297,9 +297,9 @@ function _import_to_session() {
 			$fk_product_composant = $row[2]; // produit ou code WS
 			if(empty($fk_product_composant)) continue;
 
-			$qty = (double) price2num($row[3]);
-			$qty_ref = (double) price2num($row[4]);
-			$type = $row[5];
+			$type = $row[3];
+			$qty = (double) price2num($row[4]);
+			$qty_ref = (double) price2num($row[5]);
 
 			if(empty($Tab[$fk_product]))$Tab[$fk_product]=array();
 			if(empty($Tab[$fk_product][$num_nomenclature]))$Tab[$fk_product][$num_nomenclature]=array();

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -59,7 +59,7 @@ class modnomenclature extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.2.3';
+		$this->version = '3.2.4';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
Le traitement de l'ordre des colonnes n'était pas en accord avec le fichier à télécharger + les explications de l'import sur l'interface dolibarr