### PR TITLE
FIX : Suppression de l'option "Désactivé" de la conf "Prix d'achat/revient suggéré par défaut"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## 4.3
 
+- FIX : Suppression de l'option "Désactivé" de la conf "Prix d'achat/revient suggéré par défaut" - *06/01/2022* - 4.3.4
 - FIX : Gestion des remises lignes pour la fonction recursive qui tient compte de la part de produits / services disponibles dans les ouvrages et sous ouvrages des lignes - *06/01/2022* - 4.3.3
 - FIX : Gestion des avoirs pour la fonction récursive (avec soustraction des marges en cas de ligne négative) - *04/01/2022* - 4.3.2
 - FIX : Le rang n'était pas appliqué au moment de l'import des nomenclatures + ajout du titre de la nomenclature à l'import - *05/01/2022* - 4.3.1

--- a/admin/nomenclature_setup.php
+++ b/admin/nomenclature_setup.php
@@ -233,11 +233,6 @@ if (!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE
 print '/> ';
 print '<label for="input_nomenclature_cost_type_costprice" >'.$langs->trans('CostType3').'</label>';
 
-print '<br><input id="input_nomenclature_cost_type_disable" type="radio" name="NOMENCLATURE_COST_TYPE" value="disable" ';
-if (empty($conf->global->NOMENCLATURE_COST_TYPE) || $conf->global->NOMENCLATURE_COST_TYPE === 'disable') print 'checked ';
-print '/> ';
-print '<label for="input_nomenclature_cost_type_disable" >'.$langs->trans('Disabled').'</label>';
-
 print '</td>';
 print '<td align="center" width="300"><input type="submit" class="butAction" value="'.$langs->trans("Modify").'" >';
 print '</td></tr>';

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -60,7 +60,7 @@ class modnomenclature extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '4.3.3';
+		$this->version = '4.3.4';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
## FIX : Suppression de l'option "Désactivé" de la conf "Prix d'achat/revient suggéré par défaut"

**DONE :** 
- Suppression de l'option "Désactivé" de la conf "Prix d'achat/revient suggéré par défaut"