### PR TITLE
PULL UP main | FIX : Suppression de l'option "Désactivé" de la conf "Prix d'achat/revient suggéré par défaut"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ## 4.3
 
+- FIX : Suppression de l'option "Désactivé" de la conf "Prix d'achat/revient suggéré par défaut" - *06/01/2022* - 4.3.4
 - FIX : Gestion des remises lignes pour la fonction recursive qui tient compte de la part de produits / services disponibles dans les ouvrages et sous ouvrages des lignes - *06/01/2022* - 4.3.3
 - FIX : Gestion des avoirs pour la fonction récursive (avec soustraction des marges en cas de ligne négative) - *04/01/2022* - 4.3.2
 - FIX : Le rang n'était pas appliqué au moment de l'import des nomenclatures + ajout du titre de la nomenclature à l'import - *05/01/2022* - 4.3.1

--- a/admin/nomenclature_setup.php
+++ b/admin/nomenclature_setup.php
@@ -233,11 +233,6 @@ if (!empty($conf->global->NOMENCLATURE_COST_TYPE) && $conf->global->NOMENCLATURE
 print '/> ';
 print '<label for="input_nomenclature_cost_type_costprice" >'.$langs->trans('CostType3').'</label>';
 
-print '<br><input id="input_nomenclature_cost_type_disable" type="radio" name="NOMENCLATURE_COST_TYPE" value="disable" ';
-if (empty($conf->global->NOMENCLATURE_COST_TYPE) || $conf->global->NOMENCLATURE_COST_TYPE === 'disable') print 'checked ';
-print '/> ';
-print '<label for="input_nomenclature_cost_type_disable" >'.$langs->trans('Disabled').'</label>';
-
 print '</td>';
 print '<td align="center" width="300"><input type="submit" class="butAction" value="'.$langs->trans("Modify").'" >';
 print '</td></tr>';


### PR DESCRIPTION
PULLUP : https://github.com/ATM-Consulting/dolibarr_module_nomenclature/pull/183