### PR TITLE
NEW : Action de masse - Remplacement du PMP

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## 4.6 
+
+- NEW : Ajout d'une action de masse permettant de remplacer le pmp des produits des nomenclatures sélectionnées par le prix des nomenclatures - *04/02/2022* - 4.6.0
+
 ## 4.5
 
 - NEW : Rapport chiffre d'affaires par détail nomenclature / ouvrage - *07/01/2022* - 4.5.0

--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -1386,7 +1386,7 @@ class TNomenclature extends TObjetStd
 
 
 	function UpdateProductPMPByNomPrice(){
-		global $db, $user;
+		global $db, $user, $langs;
 
         $error = 0;
 
@@ -1437,6 +1437,12 @@ class TNomenclature extends TObjetStd
             $resql_update_pmp = $db->query($sql_update_pmp);
             if($resql_update_pmp<0){
                 $error++;
+            }
+
+            if($error==0){
+				setEventMessages($langs->trans('PmpCorrectlyUpdated'), null, 'mesgs');
+            } else {
+				setEventMessages($langs->trans('PmpNotCorrectlyUpdated'), null, 'errors');
             }
         }
     }

--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -1385,7 +1385,12 @@ class TNomenclature extends TObjetStd
 	}
 
 
-	function UpdateProductPMPByNomPrice(){
+	/**
+	 * To update nomenclature product pmp by nomenclature price
+	 *
+	 * @return  void
+	 */
+	public function updateProductPMPByNomPrice(){
 		global $db, $user, $langs;
 
         $error = 0;
@@ -1413,7 +1418,7 @@ class TNomenclature extends TObjetStd
 					$res = $sub_nom->load($this->PDOdb, $obj->rowid);
 					if($res) {
 						//On reéxécute la fonction de mise à jour des PMP sur la sous-nomenclature (récursivité)
-						$sub_nom->UpdateProductPMPByNomPrice();
+						$sub_nom->updateProductPMPByNomPrice();
 					}
 				}
 			}

--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -7,6 +7,8 @@ if (!class_exists('TObjetStd'))
 }
 
 dol_include_once('/workstationatm/class/workstation.class.php');
+dol_include_once('/product/class/product.class.php');
+
 
 class TNomenclature extends TObjetStd
 {
@@ -1381,6 +1383,63 @@ class TNomenclature extends TObjetStd
 			}
 		}
 	}
+
+
+	function UpdateProductPMPByNomPrice(){
+		global $db, $user;
+
+        $error = 0;
+
+        $nom_product = new Product($db);
+        $res = $nom_product->fetch($this->fk_object);
+        if($res<0){
+            $error++;
+        }
+
+		if(!empty($this->TNomenclatureDet)){
+            //On parcourt les lignes de nomenclature
+			foreach ($this->TNomenclatureDet as $nom_det) {
+				//Pour chaque ligne, on vérifie si le produit (de la ligne) dispose d'une nomenclature
+				$sql = 'SELECT rowid, fk_object FROM ' . MAIN_DB_PREFIX . 'nomenclature';
+				$sql .= ' WHERE fk_object=' . $nom_det->fk_product;
+				$sql .= ' AND object_type="product"';
+				$resql = $db->query($sql);
+
+				//Cas où le produit (de la ligne courante) est issu d'une nomenclature
+				if($resql && $db->num_rows($resql) > 0) {
+					//On fetch la sous-nomenclature
+					$obj = $db->fetch_object($resql);
+					$sub_nom = new TNomenclature();
+					$res = $sub_nom->load($this->PDOdb, $obj->rowid);
+					if($res) {
+						//On reéxécute la fonction de mise à jour des PMP sur la sous-nomenclature (récursivité)
+						$sub_nom->UpdateProductPMPByNomPrice();
+					}
+				}
+			}
+            //On met à jour les prix de la nomenclature traitée
+			$this->setPrice($this->PDOdb, $this->qty_reference, $this->fk_object, $this->object_type);
+
+            //On met à jour le PMP du produit (de la nomenclature)
+            $priceToPmp = $this->totalPRCMO;
+            if (!empty($this->marge_object)){
+                //Pour le nouveau PMP, on applique le coeff de nomenclature
+                $sql_select_marge = 'SELECT tx FROM '.MAIN_DB_PREFIX.'nomenclature_coef WHERE code_type = '. $this->marge_object;
+                $resql_select_marge = $db->query($sql_select_marge);
+                if($resql_select_marge){
+                    $priceToPmp = $priceToPmp * $this->marge_object;
+                }
+            }
+            $nom_product->pmp = $priceToPmp;
+            $sql_update_pmp =  'UPDATE '.MAIN_DB_PREFIX.'product';
+            $sql_update_pmp.=  ' SET pmp = '. (float) $priceToPmp;
+            $sql_update_pmp.=  ' WHERE rowid = '. (int) $nom_product->id;
+            $resql_update_pmp = $db->query($sql_update_pmp);
+            if($resql_update_pmp<0){
+                $error++;
+            }
+        }
+    }
 
 }
 

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -61,7 +61,7 @@ class modnomenclature extends DolibarrModules
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '4.5.0';
+		$this->version = '4.6.0';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/langs/fr_FR/nomenclature.lang
+++ b/langs/fr_FR/nomenclature.lang
@@ -370,3 +370,8 @@ ErrorFetching = %s non trouvé
 Worstations = Workstations
 
 NomenclatureMenuCaByDetailNomenclature=CA facturé par contenu ouvrages
+
+# MassAction
+MajPmpWithBomPriceLabel=Remplacer le PMP par le prix de vente conseillé
+ConfirmMajPmp=Confirmation de mise à jour des PMP
+ConfirmMajPmpQuestion=Êtes-vous sur de vouloir mettre à jour les PMP des produits concernés par les enregistrement(s) sélectionné(s) ?

--- a/langs/fr_FR/nomenclature.lang
+++ b/langs/fr_FR/nomenclature.lang
@@ -375,3 +375,5 @@ NomenclatureMenuCaByDetailNomenclature=CA facturé par contenu ouvrages
 MajPmpWithBomPriceLabel=Remplacer le PMP par le prix de vente conseillé
 ConfirmMajPmp=Confirmation de mise à jour des PMP
 ConfirmMajPmpQuestion=Êtes-vous sur de vouloir mettre à jour les PMP des produits concernés par les enregistrement(s) sélectionné(s) ?
+PmpCorrectlyUpdated=Les PMP ont été mis à jour
+PmpNotCorrectlyUpdated=Les PMP n'ont pas été mis à jour correctement

--- a/list.php
+++ b/list.php
@@ -117,6 +117,7 @@ $TParam['title'] = array(
     
     'is_default'  => $langs->trans('is_default'),
     'qty_reference' => $langs->trans('nomenclatureQtyReference'),
+    'pmp' => $langs->trans('PMP'),
     'SellPrice'     => $langs->trans('PriceConseil'),
     //'totalPRCMO_PMP'  => $langs->trans('TotalAmountCostWithChargePMPQty'),
     'totalPRCMO_OF'  => $langs->trans('TotalAmountCostWithChargeOFQty'),
@@ -138,6 +139,7 @@ $TParam['position'] = array(
             'is_default'  => 'center',
             
             'qty_reference' => 'right',
+            'pmp' => 'right',
             'SellPrice'     => 'right',
             'totalPRCMO_PMP'  => 'right',
             'totalPRCMO_OF'  => 'right',
@@ -158,6 +160,7 @@ $TParam['type'] = array (
     'date_cre' => 'date', // [datetime], [hour], [money], [number], [integer]
     'date_maj' => 'datetime',
     'qty_reference' => 'number',
+    'pmp' => 'money',
     'totalPRCMO_PMP' => 'money',
     'totalPRCMO_OF'  => 'money',
     'totalPRCMO'     => 'money',
@@ -170,6 +173,7 @@ $TParam['search'] = array (
     'is_default'     => array('search_type'=>array(0=>$langs->trans('No'), 1=>$langs->trans('Yes') )),
     
     'qty_reference'  => array('search_type'=>true, 'table'=>'n', 'fieldname'=>'qty_reference'),
+    'pmp'  			 => array('search_type'=>true, 'table'=>'p', 'fieldname'=>'pmp'),
     'totalPRCMO_PMP' => array('search_type'=>true, 'table'=>'n', 'fieldname'=>'totalPRCMO_PMP'),
     'totalPRCMO_OF'  => array('search_type'=>true, 'table'=>'n', 'fieldname'=>'totalPRCMO_OF'),
     //'totalPRCMO'     => array('search_type'=>true, 'table'=>'n', 'fieldname'=>'totalPRCMO'),
@@ -186,10 +190,12 @@ $TParam['eval'] = array(
     
     // prix d'achat total
     //'BuyPrice' => 'nomenclature_getBuyPrice(@rowid@)',
-    
-    // prix de vente conseillé total
+
+	'PMP' => 'nomenclature_getPMP(@rowid@)',
+
+	// prix de vente conseillé total
     'SellPrice' => 'nomenclature_getSellPrice(@rowid@)',
-    
+
     // Prix de revient chargé (on affiche tjr le chargé)
     'totalPRCMO' => 'nomenclature_totalPRCMO(@rowid@)',
     
@@ -204,7 +210,7 @@ $TParam['eval'] = array(
 );
 
 // Query MYSQL
-$sql = "SELECT p.ref, n.rowid, n.is_default, n.title, n.date_maj, n.date_cre, n.fk_object, n.object_type, n.totalPRCMO_PMP, n.totalPRCMO_OF, n.totalPRCMO, n.qty_reference ";
+$sql = "SELECT p.ref, n.rowid, n.is_default, n.title, n.date_maj, n.date_cre, n.fk_object, n.object_type, n.totalPRCMO_PMP, n.totalPRCMO_OF, n.totalPRCMO, n.qty_reference, p.pmp";
 $sql.= " FROM `" . MAIN_DB_PREFIX . "nomenclature` n   ";
 $sql.= " JOIN `" . MAIN_DB_PREFIX . "product` p ON (p.rowid = n.fk_object)   ";
 $sql.= " WHERE  n.object_type = 'product' AND n.fk_nomenclature_parent = 0 ";
@@ -347,6 +353,24 @@ function nomenclature_getSellPrice($id=0){
     return '--';
 }
 
+// prix de vente conseillé total
+function nomenclature_getPMP($id=0){
+
+	global $db;
+
+	$sql = 'SELECT pmp FROM '.MAIN_DB_PREFIX.'product p';
+	$sql.= ' JOIN '.MAIN_DB_PREFIX.'nomenclature n ON p.rowid = n.fk_object';
+	$sql.= ' WHERE n.rowid='.$id;
+	$resql = $db->query($sql);
+	var_dump($resql);
+	if($resql){
+		$obj = $db->fetch_object($resql);
+		var_dump($obj);exit();
+		return $obj->pmp;
+	}
+
+	return '--';
+}
 
 // Prix de revient chargé (on affiche tjr le chargé)
 function nomenclature_totalPRCMO($id=0){

--- a/list.php
+++ b/list.php
@@ -130,7 +130,7 @@ $TParam['title'] = array(
 $TParam['hide'] = array('is_default');
 
 
-// defined list align for field/extrafields_list_array_fields.tpl.php
+// defined list align for field
 $TParam['position'] = array(
         'text-align'=> array(
             'ref' => 'left',
@@ -239,7 +239,7 @@ if($action == 'confirm_maj_pmp_massaction' && $confirmmassaction == "yes"){
 		$nom = new TNomenclature();
 		$res = $nom->load($PDOdb, $nom_id);
 		if($res){
-			$nom->UpdateProductPMPByNomPrice();
+			$nom->updateProductPMPByNomPrice();
 		}
 	}
 }elseif ($confirmmassaction != 'yes' && $massaction != 'presend' && $massaction != 'confirm_presend') {
@@ -353,7 +353,11 @@ function nomenclature_getSellPrice($id=0){
     return '--';
 }
 
-// prix de vente conseillé total
+/**
+ * To get the PMP of a product by giving its nomenclature
+ * @param int $id
+ * @return string
+ */
 function nomenclature_getPMP($id=0){
 
 	global $db;
@@ -362,10 +366,8 @@ function nomenclature_getPMP($id=0){
 	$sql.= ' JOIN '.MAIN_DB_PREFIX.'nomenclature n ON p.rowid = n.fk_object';
 	$sql.= ' WHERE n.rowid='.$id;
 	$resql = $db->query($sql);
-	var_dump($resql);
 	if($resql){
 		$obj = $db->fetch_object($resql);
-		var_dump($obj);exit();
 		return $obj->pmp;
 	}
 

--- a/nomenclature.php
+++ b/nomenclature.php
@@ -139,7 +139,8 @@ if (empty($reshook))
 		    if($fk_nomenclature>0) $n->load($PDOdb, $fk_nomenclature, false, $product->id , $qty_ref, $object_type, $fk_origin);
 		    else $n->loadByObjectId($PDOdb, $fk_object, $object_type,true, $product->id, $qty_ref, $fk_origin); // si pas de fk_nomenclature, alors on provient d'un document, donc $qty_ref tjr passé en param
 
-			if(!$n->iExist && GETPOST('type_object', 'none')!='product') { // cas où on sauvegarde depuis une ligne et qu'il faut dupliquer la nomenclature
+			//Cas où on sauvegarde depuis une ligne et qu'il faut dupliquer la nomenclature
+			if(!$n->iExist && GETPOST('type_object', 'none')!='product') {
 				$n->reinit();
 			}
 
@@ -156,6 +157,7 @@ if (empty($reshook))
 
 			if($n->is_default>0) TNomenclature::resetDefaultNomenclature($PDOdb, $n->fk_product);
 
+            //Cas ou l'on déplace une ligne
 		    if(!empty($_POST['TNomenclature'])) {
 		    	// Réorganisation des clefs du tableau au cas où l'odre a été changé par déplacement des lignes
 				$tab = array();
@@ -177,6 +179,7 @@ if (empty($reshook))
 		        }
 		    }
 
+            //Cas ou l'on ajoute un produit dans la nomenclature
 		    $fk_new_product = GETPOST('fk_new_product_'.$n->getId(), 'none');
 		    $fk_new_product_qty = GETPOST('fk_new_product_qty_'.$n->getId(), 'none');
 		    if(GETPOST('add_nomenclature', 'none') && $fk_new_product>0) {
@@ -205,6 +208,7 @@ if (empty($reshook))
                 }
             }
 
+            //Cas où l'on ajoute un nouveau poste à charge
 		    $fk_new_workstation = GETPOST('fk_new_workstation', 'none');
 		    if(GETPOST('add_workstation', 'none') && $fk_new_workstation>0 ) {
 		        $k = $n->addChild($PDOdb, 'TNomenclatureWorkstation');
@@ -222,6 +226,7 @@ if (empty($reshook))
 		    }
 
 
+            //Mise à jour des prix de la nomenclature
 			$n->setPrice($PDOdb,$qty_ref,$n->fk_object,$n->object_type, $fk_origin);
 
 		    $n->save($PDOdb);


### PR DESCRIPTION

- ## NEW : Action de masse - Remplacement du PMP

Mise en place d'une action de masse permettant de remplacer le PMP du produit des nomenclatures sélectionnées par le prix de la nomenclature correspondante.

DONE : 
- Mise ne place du système d'action de masse avec listView
- Création de l'action de masse "Remplacer le PMP par le prix de vente conseillé"
- Traitement de l'action de masse : 
          o Création de la fonction récursive UpdateProductPMPByNomPrice()
- Ajout de la colonne PMP dans la liste 