### PR TITLE
FIX : PMP filter and calculation PV price

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## 4.6 
 
+- FIX : Le filtre PMP sur la liste des nomenclatures ne fonctionnait pas. Le calcul du prix de vente conseillé n'était pas correct - *09/02/2022* - 4.6.1
 - NEW : Ajout d'une action de masse permettant de remplacer le pmp des produits des nomenclatures sélectionnées par le prix des nomenclatures - *04/02/2022* - 4.6.0
 
 ## 4.5

--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -353,7 +353,7 @@ class TNomenclature extends TObjetStd
 			$det->pv = empty($perso_price) ? $det->charged_price * $coef2 : $perso_price * $coef_qty_price;
 
 			$totalPRC+= $det->charged_price;
-			$totalPV += round($det->pv, 2);
+			$totalPV += $det->pv;
 
 			if(!empty($conf->global->NOMENCLATURE_ACTIVATE_DETAILS_COSTS)) {
 				$det->calculate_price_pmp = $det->getPrice($PDOdb, $det->qty * $coef_qty_price,'PMP') * $det->qty * $coef_qty_price;

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -61,7 +61,7 @@ class modnomenclature extends DolibarrModules
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '4.6.0';
+		$this->version = '4.6.1';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/list.php
+++ b/list.php
@@ -181,6 +181,10 @@ $TParam['search'] = array (
     'date_maj'       => array('search_type'=>true, 'table'=>'n', 'fieldname'=>'date_maj'),
 );
 
+$TParam['operator'] = array(
+  'pmp' => '= '.round('nomenclature_getPMP(@rowid@)', 2, PHP_ROUND_HALF_UP)
+);
+
 $TParam['eval'] = array(
     // array of customized field function
     'title'=>'linkToNomenclature(\'@val@\', @rowid@, \'@object_type@\', \'@fk_object@\')',


### PR DESCRIPTION
# FIX

Le filtre sur la colonne PMP dans la liste des nomenclatures ne fonctionnait pas.

Sur une nomenclature, le calcul du prix de vente conseillé n'était pas le bon et ne correspondait pas au coût de revient de la nomenclature.