### PR TITLE
Pullup fix 4.6 to main nomenclature popin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
 
 ## 4.6 
 
+- FIX : retrocompatibilité des nomenclatures non-locales présente (fatal PHP sur enregistrement en nomenclature locale)  - *12/04/2022* - 4.6.7
+- FIX : les lignes en option vidaient leur PU et PA car recalculé sur la base d'une qty à 0  - *12/04/2022* - 4.6.6
+- FIX : compatibilité avec quickcustomerprice  - *12/04/2022* - 4.6.5
+- FIX : warning division par 0 sur les lignes en option  - *12/04/2022* - 4.6.4
+- FIX : problème select2 z-index => le select2 d'ajout de produit affichait sont dropdown derrière la popin... ajout impossible - *12/04/2022* - 4.6.3
 - FIX : Ne pas mettre à jour la ligne de facture à l'ajout pour les avoirs (ça n'a pas de sens) - *11/04/2022* - 4.6.2
 - FIX : Le filtre PMP sur la liste des nomenclatures ne fonctionnait pas. Le calcul du prix de vente conseillé n'était pas correct - *09/02/2022* - 4.6.1
 - NEW : Ajout d'une action de masse permettant de remplacer le pmp des produits des nomenclatures sélectionnées par le prix des nomenclatures - *04/02/2022* - 4.6.0

--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -176,11 +176,30 @@ class Actionsnomenclature
 
 							if(td.length === 0) td = $('#row-<?php echo $lineid; ?> td:nth-child('+lineColDescriptionPos+')');
 
-							td.append('<a href="javascript:showLineNomenclature(<?php echo $showLineNomenclatureParams; ?>)"><?php echo $picto; ?></a>');
+							td.append('<a class="openPopin" href="javascript:showLineNomenclature(<?php echo $showLineNomenclatureParams; ?>)" data-lineid="<?php echo $lineid; ?>" data-fk_product="<?php echo $line->fk_product; ?>" data-element="<?php echo $object->element; ?>" data-fk_element="<?php echo $object->id; ?>"><?php echo $picto; ?></a>');
 							<?php
 						}
 					}
+
+					// si l'un de ces modules est activé, on a potentiellement des modifs de qty qui ne sont pas reportées dans l'appel initial, il faut rebuild l'appel de la popin
+					if ($conf->quickcustomerprice->enabled || $conf->quickeditline->enabled)
+					{
 					?>
+						$('.openPopin').on('click', function (e) {
+							e.preventDefault();
+							let parentTr = $(this).closest('tr');
+							let lineId = $(this).data('lineid');
+							let fk_product = $(this).data('fk_product');
+							let element = $(this).data('element');
+							let fk_element = $(this).data('fk_element');
+							let qty = parentTr.find('td.linecolqty').text(); // compat avec quickcustomerprice et quickeditline
+
+							showLineNomenclature(lineId, qty, fk_product, element, fk_element);
+						});
+					<?php
+					}
+					?>
+
 				});
 				</script>
 				<style type="text/css">

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -61,7 +61,7 @@ class modnomenclature extends DolibarrModules
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '4.6.2';
+		$this->version = '4.6.7';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
+++ b/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
@@ -390,7 +390,7 @@ class Interfacenomenclaturetrigger
 
 				$n->setPrice($PDOdb, $object->qty, $object->id, 'propal', $object->fk_propal);
 
-				$pv_calcule = round($n->totalPV / $object->qty, 5); // round car selon les cas, les nombres sont identiques mais sont consiférés comme différents (genr après la virgule il y a un 0000000000000000000000000001 qu'on ne voit pas)
+				$pv_calcule = round($n->totalPV / (!empty($object->qty) ? $object->qty: 1), 5); // round car selon les cas, les nombres sont identiques mais sont consiférés comme différents (genr après la virgule il y a un 0000000000000000000000000001 qu'on ne voit pas)
 				$pv_manuel = round($object->subprice, 5);
 				//var_dump(round($pv_calcule,5) != round($pv_manuel,3),round($pv_calcule,5), round($pv_manuel,5));exit;
 				if($pv_calcule != $pv_manuel) $pv_force = true;

--- a/lib/nomenclature.lib.php
+++ b/lib/nomenclature.lib.php
@@ -88,6 +88,14 @@ function cloneNomenclatureFromProduct(&$PDOdb, $fk_product, $fk_object, $object_
     return $res;
 }
 
+/**
+ * @param TNomenclature $n
+ * @param $object_type
+ * @param $fk_object
+ * @param $fk_origin
+ * @param $apply_nomenclature_price
+ * @return void
+ */
 function _updateObjectLine(&$n, $object_type, $fk_object, $fk_origin, $apply_nomenclature_price=false)
 {
 	global $db;
@@ -105,7 +113,8 @@ function _updateObjectLine(&$n, $object_type, $fk_object, $fk_origin, $apply_nom
 				{
 					if ($line->id == $fk_object)
 					{
-						$propal->updateline($fk_object, $n->getSellPrice($line->qty), $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $n->getBuyPrice($line->qty), $line->product_label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit);
+						$qty = $line->qty != 0 ? $line->qty : 1; // fix apply_price pour les lignes en option
+						$propal->updateline($fk_object, $n->getSellPrice($qty), $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $n->getBuyPrice($qty), $line->product_label, $line->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit);
 						$line->array_options['options_pv_force'] = false;
 						$line->insertExtraFields();
 					}
@@ -123,7 +132,8 @@ function _updateObjectLine(&$n, $object_type, $fk_object, $fk_origin, $apply_nom
 				{
 					if ($line->id == $fk_object)
 					{
-						$commande->updateline($fk_object, $line->desc, $n->getSellPrice($line->qty), $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $n->getBuyPrice($line->qty), $line->product_label, $line->special_code, $line->array_options, $line->fk_unit);
+						$qty = $line->qty != 0 ? $line->qty : 1; // fix apply_price pour les lignes en option
+						$commande->updateline($fk_object, $line->desc, $n->getSellPrice($qty), $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->date_start, $line->date_end, $line->product_type, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $n->getBuyPrice($qty), $line->product_label, $line->special_code, $line->array_options, $line->fk_unit);
 					}
 				}
 				break;
@@ -138,7 +148,8 @@ function _updateObjectLine(&$n, $object_type, $fk_object, $fk_origin, $apply_nom
 				{
 					if ($line->id == $fk_object)
 					{
-						$fac->updateline($fk_object, $line->desc, $n->getSellPrice($line->qty), $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $n->getBuyPrice($line->qty), $line->product_label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit);
+						$qty = $line->qty != 0 ? $line->qty : 1; // fix apply_price pour les lignes en option
+						$fac->updateline($fk_object, $line->desc, $n->getSellPrice($qty), $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $line->product_type, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $n->getBuyPrice($qty), $line->product_label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit);
 					}
 				}
 				break;

--- a/nomenclature.php
+++ b/nomenclature.php
@@ -500,7 +500,7 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
 		echo '<div class="error">'.$langs->trans('NonLocalNomenclature').'</div>';
 	}
 
-	$pAction = $_SERVER['PHP_SELF'].'?fk_product='.$n->fk_object;
+	$pAction = $n->getId() ? $_SERVER['PHP_SELF'].'?fk_product='.$n->fk_object : 'auto';
     $formCore=new TFormCore($pAction, 'form_nom_'.$n->getId(), 'post', false);
     if ($readonly) {
         $formCore->Set_typeaff('view'); // $formCore methods will return read-only elements instead of form inputs
@@ -1065,13 +1065,12 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
                             <?php
                             print '<label>' .$langs->trans('Qty'). '<input type="text" value="1" name="fk_new_product_qty_'.$n->getId().'" size="4" maxlength="50"/></label>';
                             print '<label>'.$langs->trans('Product').'';
+							$finished = 2;
                             if(!empty($conf->global->NOMENCLATURE_ALLOW_JUST_MP)) {
-                                print $form->select_produits('', 'fk_new_product_'.$n->getId(), '', 0,0,-1,0);
-                            }
-                            else{
-                                print $form->select_produits('', 'fk_new_product_'.$n->getId(), '', 0,0,-1,2);
-                            }
-                            print '</label>';
+								$finished = 0;
+							}
+							print $form->select_produits('', 'fk_new_product_'.$n->getId(), '', 0,0,-1,$finished);
+							print '</label>';
                             ?>
                             <span id="nomenclature-searchbycat-<?php echo $n->getId(); ?>" class="nomenclature-searchbycat" data-nomenclature="<?php echo $n->getId(); ?>"  ></span>
                             <div class="inline-block divButAction">
@@ -1419,6 +1418,12 @@ function _fiche_nomenclature(&$PDOdb, &$n,&$product, &$object, $fk_object=0, $ob
                                     */
                                     overflow: visible !important; /* Permet de ne pas tronquer le visuel après un ajout */
                                 }
+
+								/* le select2 d'ajout de produit passe derrière la popin... impossible d'ajouter un produit à une nomenclature de ligne. C'est un peu chiant. */
+								.select2-dropdown{
+									z-index: 2000;
+								}
+
                             </style>
                             <div>
                                 <?php


### PR DESCRIPTION
- FIX : retrocompatibilité des nomenclatures non-locales présentent (fatal PHP sur enregistrement en nomenclature locale)  - *12/04/2022* - 4.6.7
- FIX : les lignes en option vidaient leur PU et PA car recalculé sur la base d'une qty à 0  - *12/04/2022* - 4.6.6
- FIX : compatibilité avec quickcustomerprice  - *12/04/2022* - 4.6.5
- FIX : warning division par 0 sur les lignes en option  - *12/04/2022* - 4.6.4
- FIX : problème select2 z-index => le select2 d'ajout de produit affichait sont dropdown derrière la popin... ajout impossible - *12/04/2022* - 4.6.3