### PR TITLE
PULL UP: FIX: when quickcustomerprice is enabled, nomenclature takes qty from …

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 
 ## 4.6 
-- FIX : Devided by zero  - *23/06/2022* - 4.6.8  
+- FIX : Compatibility with quickcustomerprice causes bug due to parsing a formatted value for qty - *12/09/2022* - 4.6.9
+- FIX : Devided by zero  - *23/06/2022* - 4.6.8
 - FIX : retrocompatibilité des nomenclatures non-locales présente (fatal PHP sur enregistrement en nomenclature locale)  - *12/04/2022* - 4.6.7
 - FIX : les lignes en option vidaient leur PU et PA car recalculé sur la base d'une qty à 0  - *12/04/2022* - 4.6.6
 - FIX : compatibilité avec quickcustomerprice  - *12/04/2022* - 4.6.5

--- a/class/actions_nomenclature.class.php
+++ b/class/actions_nomenclature.class.php
@@ -192,7 +192,7 @@ class Actionsnomenclature
 							let fk_product = $(this).data('fk_product');
 							let element = $(this).data('element');
 							let fk_element = $(this).data('fk_element');
-							let qty = parentTr.find('td.linecolqty').text(); // compat avec quickcustomerprice et quickeditline
+							let qty = price2numjs(parentTr.find('td.linecolqty').text()); // compat avec quickcustomerprice et quickeditline
 
 							showLineNomenclature(lineId, qty, fk_product, element, fk_element);
 						});

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -61,7 +61,7 @@ class modnomenclature extends DolibarrModules
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '4.6.8';
+		$this->version = '4.6.9';
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);


### PR DESCRIPTION
…the DOM but it is formatted (ex: "2 560,00" instead of "2560") so parsing fails

cf. https://github.com/ATM-Consulting/dolibarr_module_nomenclature/pull/205