### PR TITLE
FIX [DA023030] : empty nomenclature

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## 4.9
-
+- FIX : DA023030 - Lors de l'ajout d'un produit sans nomenclature, la modale affiche une nomenclature vide, celle-ci doit rester vide jusqu'à ce qu'une actions soit effectué depuis la modale *16/03/2023* 4.9.8
 - FIX : Compatibilité v17 - Warning PHP 8 *26/01/2023* 4.9.7
 - FIX : Compatibilité v17 *04/01/2023* 4.9.6
 - FIX : DA022742 PDO Error : try to save NAN instead of a number *04/01/2023* 4.9.5

--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -812,15 +812,20 @@ class TNomenclature extends TObjetStd
         }
         $this->load_original($PDOdb, $fk_product, $qty);
 
+		$this->setAll();
 
-        // Cas où un produit a été ajouté à une ligne avant la création d'une nomenclature pour ce produit
-        // La modale ne doit pas prendre les infos de la nomenclature ulterieurement créée. Elle a été créée à vide et doit le rester jusqu'à ce qu'une opération soit effectue depuis la modale
-        if(!empty($this->TNomenclatureDet) && $this->TNomenclatureDet[0]->fk_nomenclature != $this->rowid) {
+		// Cas où un produit a été ajouté à une ligne avant la création d'une nomenclature pour ce produit
+		// La modale ne doit pas prendre les infos de la nomenclature ulterieurement créée. Elle a été créée à vide et doit le rester jusqu'à ce qu'une opération soit effectue depuis la modale
+
+        $sql2 = "SELECT fk_nomenclature_parent FROM ".MAIN_DB_PREFIX."nomenclature WHERE rowid =".$this->rowid;
+        $PDOdb->Execute($sql2);
+        $obj2 = $PDOdb->Get_line();
+
+        if(empty($obj2->fk_nomenclature_parent)) {
             $this->TNomenclatureDet = array();
             return $res;
         }
 
-		$this->setAll();
 
 		$this->loadThmObject($PDOdb, $object_type, $fk_origin);
 

--- a/class/nomenclature.class.php
+++ b/class/nomenclature.class.php
@@ -810,8 +810,16 @@ class TNomenclature extends TObjetStd
         if($obj = $PDOdb->Get_line()) {
             $res = $this->load($PDOdb, $obj->rowid, $loadProductWSifEmpty, 0, 1, $object_type, $fk_origin);
         }
-
         $this->load_original($PDOdb, $fk_product, $qty);
+
+
+        // Cas où un produit a été ajouté à une ligne avant la création d'une nomenclature pour ce produit
+        // La modale ne doit pas prendre les infos de la nomenclature ulterieurement créée. Elle a été créée à vide et doit le rester jusqu'à ce qu'une opération soit effectue depuis la modale
+        if(!empty($this->TNomenclatureDet) && $this->TNomenclatureDet[0]->fk_nomenclature != $this->rowid) {
+            $this->TNomenclatureDet = array();
+            return $res;
+        }
+
 		$this->setAll();
 
 		$this->loadThmObject($PDOdb, $object_type, $fk_origin);

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -61,7 +61,7 @@ class modnomenclature extends DolibarrModules
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '4.9.7';
+		$this->version = '4.9.8';
 
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';


### PR DESCRIPTION
## FIX : 

Lors de l'ajout d'un produit sans nomenclature, la modale affiche une nomenclature vide, celle-ci doit rester vide jusqu'à ce qu'une actions soit effectué depuis la modale