### PR TITLE
Wrong table creation order prevents module activation of fresh install

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-
+- FIX: order of inital table creation not correct. TNomenclatureDet checks for table llx_nomenclature_coef which needs to be created first *19/06/2023*
 
 ## 4.9
 - FIX : DA023411 - On ne voit plus les enfants sur une fiche nomenclature sur un produit *31/05/2023* 4.9.12

--- a/script/create-maj-base.php
+++ b/script/create-maj-base.php
@@ -26,14 +26,13 @@ $PDOdb=new TPDOdb;
 $o=new TNomenclature($db);
 $o->init_db_by_vars($PDOdb);
 
+$o=new TNomenclatureCoef($db);
+$o->init_db_by_vars($PDOdb);
+
 $o=new TNomenclatureDet($db);
 $o->init_db_by_vars($PDOdb);
 
-
 $o=new TNomenclatureWorkstation($db);
-$o->init_db_by_vars($PDOdb);
-
-$o=new TNomenclatureCoef($db);
 $o->init_db_by_vars($PDOdb);
 
 /*


### PR DESCRIPTION
Hi,

currently it is not possible to activate this module for the first time for a new dolibarr installation. The order of the created tables was not correct. First the lines are created but the check for the coef table and relies on them. Therefore the coef table needs to be created before.

Best regards,
Sven