### PR TITLE
FIX - Placement de la popin ouvrage depuis une propal card

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## RELEASE 4.11
 
+- FIX : Le champ d'ajout des produits sur la popin des ouvrages depuis une Propal fonctionne mais remonte en haut du page pour aucune raison tandisque la popin reste en bas - *10/04/2024* - 4.11.1 
 - NEW : Dolibarr compatibility V19 - *04/12/2023* - 4.11.0  
   	Changed Dolibarr compatibility range to 15 min - 19 max  
   	Changed PHP compatibility range to 7.0 min - 8.2 max

--- a/core/modules/modnomenclature.class.php
+++ b/core/modules/modnomenclature.class.php
@@ -61,7 +61,7 @@ class modnomenclature extends DolibarrModules
 		$this->description = "Description of module nomenclature";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '4.11.0';
+		$this->version = '4.11.1';
 
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';

--- a/js/nomenclature.js.php
+++ b/js/nomenclature.js.php
@@ -108,27 +108,36 @@ function showLineNomenclature(fk_line, qty, fk_product, object_type, fk_origin) 
 
        }
 
-       var openDialog = function(data) {
+	var openDialog = function (data) {
 
-               $("#dialog-nomenclature").remove();
+		$("#dialog-nomenclature").remove();
 
-               $('body').append('<div id="dialog-nomenclature"></div>');
+		$('body').append('<div id="dialog-nomenclature"></div>');
 
-               $div = $("#dialog-nomenclature");
-               $div.html(data);
-               bindItem();
+		$div = $("#dialog-nomenclature");
+		$div.html(data);
+		bindItem();
 
-               $("#dialog-nomenclature").dialog({
-                  resizable: true,
-                  modal: true,
-                  dialogClass: "dialogSouldBeZindexed",
-                  width:'90%',
-                  title:"<?php echo $langs->trans('Nomenclature'); ?>",
-                  buttons: {
-
-                  }
-               });
-       };
+		$("#dialog-nomenclature").dialog({
+			resizable: true,
+			modal: true,
+			dialogClass: "dialogSouldBeZindexed",
+			width: '90%',
+			title: "<?php echo $langs->trans('Nomenclature'); ?>",
+			top: 0,
+			open: function (event, ui) {
+				// Positionnement du dialogue en haut de la page
+				$(this).closest('.ui-dialog').css({
+					'top': '10px'
+				});
+				// Remonter en haut de page
+				$('html, body').animate({
+					scrollTop: 0
+				}, 0);
+			},
+			buttons: {}
+		});
+	};
 
 /* nomenclature/nomenclature.php?fk_product=2&lineid=4&object_type=commande&qty=1 */
        $.ajax({


### PR DESCRIPTION
Le champ d'ajout des produits sur la popin des ouvrages depuis une Propal fonctionne mais remonte en haut du page pour aucune raison tandisque la popin reste en bas