### PR TITLE
fix usage of wrong rounding parameter for calculation of unit price

### DIFF
--- a/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
+++ b/core/triggers/interface_50_modnomenclature_nomenclaturetrigger.class.php
@@ -464,7 +464,7 @@ class Interfacenomenclaturetrigger
 
 		if(empty($sell_price_to_use)) return 0;
 
-		$sell_price_to_use = price2num($sell_price_to_use,'MT'); //round value
+		$sell_price_to_use = price2num($sell_price_to_use,'MU'); //round value
 
 		if($object_type=='commande') {
 //		var_dump($n->totalPV, $object_type,$object);exit;


### PR DESCRIPTION
Currently the rouding option MT is used to round the unit price. But this uses the config for totals with tax (MAIN_MAX_DECIMALS_TOT). As this calculates the net price per unit, the correct rouding option is MU which uses MAIN_MAX_DECIMALS_UNIT instead.